### PR TITLE
feat(issue-154): cut over social chat messages to profile-scoped thread routes

### DIFF
--- a/apps/api/specs/scenario/singlepagestartup/issue-154/backend-social-chat-threads.scenario.spec.ts
+++ b/apps/api/specs/scenario/singlepagestartup/issue-154/backend-social-chat-threads.scenario.spec.ts
@@ -1,0 +1,448 @@
+/**
+ * BDD Suite: issue-154 social chat thread behavior with real API and database.
+ *
+ * Given: API server, database, and fixed RBAC scenario subject are running from apps/api/.env.
+ * When: subject works with chat threads through canonical chat-thread routes.
+ * Then: default-thread bootstrap, thread routing, and thread-link normalization are consistent and rerunnable.
+ */
+
+import { api as subjectApi } from "@sps/rbac/models/subject/sdk/server";
+import { api as socialModuleProfileApi } from "@sps/social/models/profile/sdk/server";
+import { api as socialModuleMessageApi } from "@sps/social/models/message/sdk/server";
+import { api as socialModuleChatsToMessagesApi } from "@sps/social/relations/chats-to-messages/sdk/server";
+import { api as socialModuleChatsToThreadsApi } from "@sps/social/relations/chats-to-threads/sdk/server";
+import { api as socialModuleProfilesToMessagesApi } from "@sps/social/relations/profiles-to-messages/sdk/server";
+import { api as socialModuleThreadsToMessagesApi } from "@sps/social/relations/threads-to-messages/sdk/server";
+import { api as subjectsToSocialModuleProfilesApi } from "@sps/rbac/relations/subjects-to-social-module-profiles/sdk/server";
+import { IModel as ISocialModuleThread } from "@sps/social/models/thread/sdk/model";
+import { loadScenarioEnv, getApiUrl, getRequiredEnv } from "./test-utils/env";
+
+describe("Given: issue-154 social chat thread scenario", () => {
+  let host = "";
+  let secretKey = "";
+  let subjectId = "";
+  let jwt = "";
+  let socialModuleProfileId = "";
+
+  const authHeaders = () => {
+    return {
+      Authorization: `Bearer ${jwt}`,
+    };
+  };
+
+  const secretHeaders = () => {
+    return {
+      "X-RBAC-SECRET-KEY": secretKey,
+    };
+  };
+
+  const parseStatus = (error: unknown) => {
+    const err = error as any;
+
+    if (typeof err?.status === "number") {
+      return err.status;
+    }
+
+    if (typeof err?.cause?.status === "number") {
+      return err.cause.status;
+    }
+
+    if (typeof err?.message === "string") {
+      try {
+        const parsedMessage = JSON.parse(err.message);
+        if (typeof parsedMessage?.status === "number") {
+          return parsedMessage.status;
+        }
+      } catch {}
+    }
+
+    return 500;
+  };
+
+  const getChatId = (chatPayload: any) => {
+    const chatId = chatPayload?.id || chatPayload?.socialModuleChat?.id;
+
+    if (!chatId) {
+      throw new Error(
+        `Create chat response has no chat id: ${JSON.stringify(chatPayload)}`,
+      );
+    }
+
+    return chatId;
+  };
+
+  const getSingleDefaultThread = (threads: ISocialModuleThread[]) => {
+    const defaultThreads = threads.filter((thread) => {
+      return thread.variant === "default";
+    });
+
+    expect(defaultThreads).toHaveLength(1);
+
+    return defaultThreads[0];
+  };
+
+  const listSubjectProfileChats = async () => {
+    const chats = await subjectApi.socialModuleProfileFindByIdChatFind({
+      host,
+      id: subjectId,
+      socialModuleProfileId,
+      params: {
+        cb: Date.now().toString(),
+      },
+      options: {
+        headers: authHeaders(),
+      },
+    });
+
+    return chats || [];
+  };
+
+  const clearSubjectProfileChats = async () => {
+    const chats = await listSubjectProfileChats();
+
+    for (const chat of chats) {
+      try {
+        await subjectApi.socialModuleProfileFindByIdChatFindByIdDelete({
+          host,
+          id: subjectId,
+          socialModuleProfileId,
+          socialModuleChatId: chat.id,
+          options: {
+            headers: authHeaders(),
+          },
+        });
+      } catch {}
+    }
+  };
+
+  const createSubjectProfileChat = async () => {
+    const chatPayload = await subjectApi.socialModuleChatCreate({
+      host,
+      id: subjectId,
+      data: {},
+      options: {
+        headers: authHeaders(),
+      },
+    });
+
+    return {
+      id: getChatId(chatPayload),
+      raw: chatPayload,
+    };
+  };
+
+  const listChatThreads = async (socialModuleChatId: string) => {
+    const threads = await subjectApi.socialModuleChatFindByIdThreadFind({
+      host,
+      id: subjectId,
+      socialModuleChatId,
+      params: {
+        cb: Date.now().toString(),
+      },
+      options: {
+        headers: authHeaders(),
+      },
+    });
+
+    return threads || [];
+  };
+
+  const createCustomThread = async (props: {
+    socialModuleChatId: string;
+    title?: string;
+  }) => {
+    const thread = await subjectApi.socialModuleChatFindByIdThreadCreate({
+      host,
+      id: subjectId,
+      socialModuleChatId: props.socialModuleChatId,
+      data: {
+        title:
+          props.title || `issue-154-custom-thread-${Date.now().toString(36)}`,
+      },
+      options: {
+        headers: authHeaders(),
+      },
+    });
+
+    if (!thread?.id) {
+      throw new Error(
+        `Create custom thread response has no id: ${JSON.stringify(thread)}`,
+      );
+    }
+
+    return thread;
+  };
+
+  const createThreadMessage = async (props: {
+    socialModuleChatId: string;
+    socialModuleThreadId: string;
+    description: string;
+    sourceSystemId?: string;
+  }) => {
+    const message =
+      await subjectApi.socialModuleProfileFindByIdChatFindByIdThreadFindByIdMessageCreate(
+        {
+          host,
+          id: subjectId,
+          socialModuleProfileId,
+          socialModuleChatId: props.socialModuleChatId,
+          socialModuleThreadId: props.socialModuleThreadId,
+          data: {
+            description: props.description,
+            ...(props.sourceSystemId
+              ? {
+                  sourceSystemId: props.sourceSystemId,
+                }
+              : {}),
+          },
+          options: {
+            headers: authHeaders(),
+          },
+        },
+      );
+
+    if (!message?.id) {
+      throw new Error(
+        `Create thread message response has no id: ${JSON.stringify(message)}`,
+      );
+    }
+
+    return message;
+  };
+
+  const listThreadMessages = async (props: {
+    socialModuleChatId: string;
+    socialModuleThreadId: string;
+  }) => {
+    const messages =
+      await subjectApi.socialModuleProfileFindByIdChatFindByIdThreadFindByIdMessageFind(
+        {
+          host,
+          id: subjectId,
+          socialModuleProfileId,
+          socialModuleChatId: props.socialModuleChatId,
+          socialModuleThreadId: props.socialModuleThreadId,
+          params: {
+            cb: Date.now().toString(),
+          },
+          options: {
+            headers: authHeaders(),
+          },
+        },
+      );
+
+    return messages || [];
+  };
+
+  beforeAll(async () => {
+    loadScenarioEnv();
+    host = getApiUrl();
+    secretKey = getRequiredEnv("RBAC_SECRET_KEY");
+
+    const email = getRequiredEnv("RBAC_SUBJECT_IDENTITY_EMAIL");
+    const password = getRequiredEnv("RBAC_SUBJECT_IDENTITY_PASSWORD");
+
+    const auth = await subjectApi.authenticationEmailAndPasswordAuthentication({
+      host,
+      data: {
+        login: email,
+        password,
+      },
+    });
+
+    if (!auth?.jwt) {
+      throw new Error(
+        `Authentication payload does not include jwt: ${JSON.stringify(auth)}`,
+      );
+    }
+
+    jwt = auth.jwt;
+
+    const me = await subjectApi.authenticationMe({
+      host,
+      options: {
+        headers: authHeaders(),
+      },
+    });
+
+    if (!me?.id) {
+      throw new Error(
+        `Authentication me payload does not include id: ${JSON.stringify(me)}`,
+      );
+    }
+
+    subjectId = me.id;
+
+    const subjectToProfiles = await subjectsToSocialModuleProfilesApi.find({
+      params: {
+        filters: {
+          and: [
+            {
+              column: "subjectId",
+              method: "eq",
+              value: subjectId,
+            },
+          ],
+        },
+        limit: 1,
+      },
+      options: {
+        headers: secretHeaders(),
+      },
+    });
+
+    const existingSocialModuleProfileId =
+      subjectToProfiles?.[0]?.socialModuleProfileId;
+
+    if (existingSocialModuleProfileId) {
+      socialModuleProfileId = existingSocialModuleProfileId;
+      return;
+    }
+
+    const socialModuleProfile = await socialModuleProfileApi.create({
+      data: {},
+      options: {
+        headers: secretHeaders(),
+      },
+    });
+
+    if (!socialModuleProfile?.id) {
+      throw new Error("Could not create social profile for scenario subject");
+    }
+
+    await subjectsToSocialModuleProfilesApi.create({
+      data: {
+        subjectId,
+        socialModuleProfileId: socialModuleProfile.id,
+      },
+      options: {
+        headers: secretHeaders(),
+      },
+    });
+
+    socialModuleProfileId = socialModuleProfile.id;
+  });
+
+  beforeEach(async () => {
+    await clearSubjectProfileChats();
+  });
+
+  afterAll(async () => {
+    await clearSubjectProfileChats();
+  });
+
+  /**
+   * BDD Scenario
+   * Given: subject has a social profile.
+   * When: subject creates a new chat.
+   * Then: chat has exactly one default thread.
+   */
+  it("When: chat is created Then: exactly one default thread exists", async () => {
+    const socialModuleChat = await createSubjectProfileChat();
+
+    const threads = await listChatThreads(socialModuleChat.id);
+
+    expect(threads.length).toBeGreaterThan(0);
+    getSingleDefaultThread(threads);
+  });
+
+  /**
+   * BDD Scenario
+   * Given: chat has default and custom threads.
+   * When: subject sends messages into each thread and fetches messages by thread route.
+   * Then: each route returns only messages from its selected thread.
+   */
+  it("When: messages are created in different threads Then: thread routes return isolated message sets", async () => {
+    const socialModuleChat = await createSubjectProfileChat();
+
+    const initialThreads = await listChatThreads(socialModuleChat.id);
+    const defaultThread = getSingleDefaultThread(initialThreads);
+
+    const customThread = await createCustomThread({
+      socialModuleChatId: socialModuleChat.id,
+      title: `issue-154-custom-thread-${Date.now().toString(36)}`,
+    });
+
+    const defaultThreadMessage = await createThreadMessage({
+      socialModuleChatId: socialModuleChat.id,
+      socialModuleThreadId: defaultThread.id,
+      description: `issue-154 default thread message ${Date.now()}`,
+    });
+
+    const customThreadMessage = await createThreadMessage({
+      socialModuleChatId: socialModuleChat.id,
+      socialModuleThreadId: customThread.id,
+      description: `issue-154 custom thread message ${Date.now()}`,
+    });
+
+    const defaultThreadMessages = await listThreadMessages({
+      socialModuleChatId: socialModuleChat.id,
+      socialModuleThreadId: defaultThread.id,
+    });
+    const customThreadMessages = await listThreadMessages({
+      socialModuleChatId: socialModuleChat.id,
+      socialModuleThreadId: customThread.id,
+    });
+
+    const defaultThreadMessageIds = new Set(
+      defaultThreadMessages.map((message) => message.id),
+    );
+    const customThreadMessageIds = new Set(
+      customThreadMessages.map((message) => message.id),
+    );
+
+    expect(defaultThreadMessageIds.has(defaultThreadMessage.id)).toBe(true);
+    expect(defaultThreadMessageIds.has(customThreadMessage.id)).toBe(false);
+    expect(customThreadMessageIds.has(customThreadMessage.id)).toBe(true);
+    expect(customThreadMessageIds.has(defaultThreadMessage.id)).toBe(false);
+  });
+
+  /**
+   * BDD Scenario
+   * Given: subject has two chats with different thread sets.
+   * When: subject tries to post into chat A using thread id from chat B.
+   * Then: API rejects cross-chat thread usage.
+   */
+  it("When: thread does not belong to chat Then: thread-scoped message create is rejected", async () => {
+    const firstChat = await createSubjectProfileChat();
+    const secondChat = await createSubjectProfileChat();
+
+    const firstChatThreads = await listChatThreads(firstChat.id);
+    const secondChatThreads = await listChatThreads(secondChat.id);
+
+    const firstChatDefaultThread = getSingleDefaultThread(firstChatThreads);
+    const secondChatDefaultThread = getSingleDefaultThread(secondChatThreads);
+
+    expect(firstChatDefaultThread.id).not.toBe(secondChatDefaultThread.id);
+
+    let invalidCreateStatus = 200;
+    try {
+      await subjectApi.socialModuleProfileFindByIdChatFindByIdThreadFindByIdMessageCreate(
+        {
+          host,
+          id: subjectId,
+          socialModuleProfileId,
+          socialModuleChatId: firstChat.id,
+          socialModuleThreadId: secondChatDefaultThread.id,
+          data: {
+            description: `issue-154 invalid cross-chat thread message ${Date.now()}`,
+          },
+          options: {
+            headers: authHeaders(),
+          },
+        },
+      );
+    } catch (error) {
+      invalidCreateStatus = parseStatus(error);
+    }
+
+    expect(invalidCreateStatus).toBeGreaterThanOrEqual(400);
+
+    const firstChatDefaultThreadMessages = await listThreadMessages({
+      socialModuleChatId: firstChat.id,
+      socialModuleThreadId: firstChatDefaultThread.id,
+    });
+
+    expect(firstChatDefaultThreadMessages).toHaveLength(0);
+  });
+});

--- a/apps/api/specs/scenario/singlepagestartup/issue-154/test-utils/env.ts
+++ b/apps/api/specs/scenario/singlepagestartup/issue-154/test-utils/env.ts
@@ -1,0 +1,38 @@
+import dotenv from "dotenv";
+import path from "path";
+
+let loaded = false;
+
+export function loadScenarioEnv() {
+  if (loaded) {
+    return;
+  }
+
+  dotenv.config({
+    path: path.resolve(process.cwd(), "apps/api/.env"),
+  });
+
+  dotenv.config({
+    path: path.resolve(process.cwd(), "apps/host/.env.local"),
+  });
+
+  loaded = true;
+}
+
+export function getRequiredEnv(name: string): string {
+  loadScenarioEnv();
+
+  const value = process.env[name];
+
+  if (!value) {
+    throw new Error(`Missing required env variable: ${name}`);
+  }
+
+  return value;
+}
+
+export function getApiUrl(): string {
+  loadScenarioEnv();
+
+  return process.env["API_SERVICE_URL"] || "http://localhost:4000";
+}

--- a/libs/modules/agent/models/agent/backend/app/api/src/lib/bootstrap.ts
+++ b/libs/modules/agent/models/agent/backend/app/api/src/lib/bootstrap.ts
@@ -25,6 +25,8 @@ import { Repository as SocialProfileRepository } from "@sps/social/models/profil
 import { Configuration as SocialProfileConfiguration } from "@sps/social/models/profile/backend/app/api/src/lib/configuration";
 import { Repository as SocialChatRepository } from "@sps/social/models/chat/backend/app/api/src/lib/repository";
 import { Configuration as SocialChatConfiguration } from "@sps/social/models/chat/backend/app/api/src/lib/configuration";
+import { Repository as SocialThreadRepository } from "@sps/social/models/thread/backend/app/api/src/lib/repository";
+import { Configuration as SocialThreadConfiguration } from "@sps/social/models/thread/backend/app/api/src/lib/configuration";
 import { Repository as SocialMessageRepository } from "@sps/social/models/message/backend/app/api/src/lib/repository";
 import { Configuration as SocialMessageConfiguration } from "@sps/social/models/message/backend/app/api/src/lib/configuration";
 import { Repository as SocialActionRepository } from "@sps/social/models/action/backend/app/api/src/lib/repository";
@@ -35,10 +37,14 @@ import { Repository as SocialProfilesToMessagesRepository } from "@sps/social/re
 import { Configuration as SocialProfilesToMessagesConfiguration } from "@sps/social/relations/profiles-to-messages/backend/app/api/src/lib/configuration";
 import { Repository as SocialProfilesToActionsRepository } from "@sps/social/relations/profiles-to-actions/backend/app/api/src/lib/repository";
 import { Configuration as SocialProfilesToActionsConfiguration } from "@sps/social/relations/profiles-to-actions/backend/app/api/src/lib/configuration";
+import { Repository as SocialChatsToThreadsRepository } from "@sps/social/relations/chats-to-threads/backend/app/api/src/lib/repository";
+import { Configuration as SocialChatsToThreadsConfiguration } from "@sps/social/relations/chats-to-threads/backend/app/api/src/lib/configuration";
 import { Repository as SocialChatsToMessagesRepository } from "@sps/social/relations/chats-to-messages/backend/app/api/src/lib/repository";
 import { Configuration as SocialChatsToMessagesConfiguration } from "@sps/social/relations/chats-to-messages/backend/app/api/src/lib/configuration";
 import { Repository as SocialChatsToActionsRepository } from "@sps/social/relations/chats-to-actions/backend/app/api/src/lib/repository";
 import { Configuration as SocialChatsToActionsConfiguration } from "@sps/social/relations/chats-to-actions/backend/app/api/src/lib/configuration";
+import { Repository as SocialThreadsToMessagesRepository } from "@sps/social/relations/threads-to-messages/backend/app/api/src/lib/repository";
+import { Configuration as SocialThreadsToMessagesConfiguration } from "@sps/social/relations/threads-to-messages/backend/app/api/src/lib/configuration";
 import { Repository as RbacSubjectRepository } from "@sps/rbac/models/subject/backend/app/api/src/lib/repository";
 import { Configuration as RbacSubjectConfiguration } from "@sps/rbac/models/subject/backend/app/api/src/lib/configuration";
 import { Repository as RbacRoleRepository } from "@sps/rbac/models/role/backend/app/api/src/lib/repository";
@@ -103,6 +109,9 @@ const bindings = new ContainerModule((bind: interfaces.Bind) => {
         chat: new CRUDService<any>(
           new SocialChatRepository(new SocialChatConfiguration()),
         ),
+        thread: new CRUDService<any>(
+          new SocialThreadRepository(new SocialThreadConfiguration()),
+        ),
         message: new CRUDService<any>(
           new SocialMessageRepository(new SocialMessageConfiguration()),
         ),
@@ -124,6 +133,11 @@ const bindings = new ContainerModule((bind: interfaces.Bind) => {
             new SocialProfilesToActionsConfiguration(),
           ),
         ),
+        chatsToThreads: new CRUDService<any>(
+          new SocialChatsToThreadsRepository(
+            new SocialChatsToThreadsConfiguration(),
+          ),
+        ),
         chatsToMessages: new CRUDService<any>(
           new SocialChatsToMessagesRepository(
             new SocialChatsToMessagesConfiguration(),
@@ -132,6 +146,11 @@ const bindings = new ContainerModule((bind: interfaces.Bind) => {
         chatsToActions: new CRUDService<any>(
           new SocialChatsToActionsRepository(
             new SocialChatsToActionsConfiguration(),
+          ),
+        ),
+        threadsToMessages: new CRUDService<any>(
+          new SocialThreadsToMessagesRepository(
+            new SocialThreadsToMessagesConfiguration(),
           ),
         ),
       };

--- a/libs/modules/agent/models/agent/backend/app/api/src/lib/di.ts
+++ b/libs/modules/agent/models/agent/backend/app/api/src/lib/di.ts
@@ -10,13 +10,16 @@ export interface IHostPageReadService extends IReadService {
 export interface ISocialModule {
   profile: IReadService;
   chat: IReadService;
+  thread: IReadService;
   message: IReadService;
   action: IReadService;
   profilesToChats: IReadService;
   profilesToMessages: IReadService;
   profilesToActions: IReadService;
+  chatsToThreads: IReadService;
   chatsToMessages: IReadService;
   chatsToActions: IReadService;
+  threadsToMessages: IReadService;
 }
 
 export interface IRbacModule {

--- a/libs/modules/agent/models/agent/backend/app/api/src/lib/service/singlepage/index.spec.ts
+++ b/libs/modules/agent/models/agent/backend/app/api/src/lib/service/singlepage/index.spec.ts
@@ -1,0 +1,149 @@
+/**
+ * BDD Suite: agent thread normalization routine.
+ *
+ * Given: chat histories can contain legacy messages without thread links.
+ * When: normalization runs before thread resolution.
+ * Then: only missing links are created and repeated runs remain idempotent.
+ */
+
+import { Service } from "./index";
+import { api as socialModuleThreadsToMessagesApi } from "@sps/social/relations/threads-to-messages/sdk/server";
+
+jest.mock("@sps/social/relations/threads-to-messages/sdk/server", () => {
+  return {
+    api: {
+      create: jest.fn(),
+    },
+  };
+});
+
+type FindMock = jest.Mock<Promise<any[] | undefined>, [any]>;
+
+function createServiceWithMocks(props?: {
+  chatsToMessages?: any[];
+  chatsToThreads?: any[];
+  threadsToMessages?: any[];
+}) {
+  const service = Object.create(Service.prototype) as Service;
+  const chatsToMessagesFind: FindMock = jest
+    .fn()
+    .mockResolvedValue(props?.chatsToMessages);
+  const chatsToThreadsFind: FindMock = jest
+    .fn()
+    .mockResolvedValue(props?.chatsToThreads);
+  const threadsToMessagesFind: FindMock = jest
+    .fn()
+    .mockResolvedValue(props?.threadsToMessages);
+
+  (service as any).socialModule = {
+    chatsToMessages: { find: chatsToMessagesFind },
+    chatsToThreads: { find: chatsToThreadsFind },
+    threadsToMessages: { find: threadsToMessagesFind },
+  };
+  (service as any).ensureDefaultThreadForChat = jest.fn().mockResolvedValue({
+    id: "thread-default",
+    variant: "default",
+  });
+
+  return {
+    service,
+    mocks: {
+      chatsToMessagesFind,
+      chatsToThreadsFind,
+      threadsToMessagesFind,
+      ensureDefaultThreadForChat: (service as any)
+        .ensureDefaultThreadForChat as jest.Mock,
+      createThreadToMessage:
+        socialModuleThreadsToMessagesApi.create as jest.Mock,
+    },
+  };
+}
+
+describe("agent thread normalization routine", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  /**
+   * BDD Scenario
+   * Given: a chat has messages where some are still threadless or linked to foreign threads.
+   * When: normalization is executed for that chat.
+   * Then: only missing/invalid links are created to the default thread.
+   */
+  it("creates links only for messages without valid chat thread relation", async () => {
+    const { service, mocks } = createServiceWithMocks({
+      chatsToMessages: [
+        { chatId: "chat-1", messageId: "message-1" },
+        { chatId: "chat-1", messageId: "message-2" },
+        { chatId: "chat-1", messageId: "message-3" },
+      ],
+      chatsToThreads: [{ chatId: "chat-1", threadId: "thread-custom" }],
+      threadsToMessages: [
+        { messageId: "message-2", threadId: "thread-custom" },
+        { messageId: "message-3", threadId: "thread-foreign" },
+      ],
+    });
+
+    const result = await service.normalizeChatThreadsAndMessageLinks({
+      socialModuleChatId: "chat-1",
+      secretKey: "rbac-secret",
+    });
+
+    expect(result).toBe("thread-default");
+    expect(mocks.ensureDefaultThreadForChat).toHaveBeenCalledWith({
+      socialModuleChatId: "chat-1",
+      secretKey: "rbac-secret",
+    });
+    expect(mocks.createThreadToMessage).toHaveBeenCalledTimes(2);
+    expect(mocks.createThreadToMessage).toHaveBeenNthCalledWith(1, {
+      data: {
+        threadId: "thread-default",
+        messageId: "message-1",
+      },
+      options: {
+        headers: {
+          "X-RBAC-SECRET-KEY": "rbac-secret",
+        },
+      },
+    });
+    expect(mocks.createThreadToMessage).toHaveBeenNthCalledWith(2, {
+      data: {
+        threadId: "thread-default",
+        messageId: "message-3",
+      },
+      options: {
+        headers: {
+          "X-RBAC-SECRET-KEY": "rbac-secret",
+        },
+      },
+    });
+  });
+
+  /**
+   * BDD Scenario
+   * Given: all chat messages already have valid links to chat-owned threads.
+   * When: normalization is executed again.
+   * Then: no duplicate links are created.
+   */
+  it("is idempotent when valid links already exist", async () => {
+    const { service, mocks } = createServiceWithMocks({
+      chatsToMessages: [
+        { chatId: "chat-2", messageId: "message-1" },
+        { chatId: "chat-2", messageId: "message-2" },
+      ],
+      chatsToThreads: [{ chatId: "chat-2", threadId: "thread-custom" }],
+      threadsToMessages: [
+        { messageId: "message-1", threadId: "thread-default" },
+        { messageId: "message-2", threadId: "thread-custom" },
+      ],
+    });
+
+    const result = await service.normalizeChatThreadsAndMessageLinks({
+      socialModuleChatId: "chat-2",
+      secretKey: "rbac-secret",
+    });
+
+    expect(result).toBe("thread-default");
+    expect(mocks.createThreadToMessage).not.toHaveBeenCalled();
+  });
+});

--- a/libs/modules/agent/models/agent/backend/app/api/src/lib/service/singlepage/index.ts
+++ b/libs/modules/agent/models/agent/backend/app/api/src/lib/service/singlepage/index.ts
@@ -21,6 +21,9 @@ import { IModel as ISocialModuleAction } from "@sps/social/models/action/sdk/mod
 import { IModel as IRbacModuleSubject } from "@sps/rbac/models/subject/sdk/model";
 import { IModel as IEcommerceModuleProduct } from "@sps/ecommerce/models/product/sdk/model";
 import { api as rbacModuleSubjectApi } from "@sps/rbac/models/subject/sdk/server";
+import { api as socialModuleThreadApi } from "@sps/social/models/thread/sdk/server";
+import { api as socialModuleChatsToThreadsApi } from "@sps/social/relations/chats-to-threads/sdk/server";
+import { api as socialModuleThreadsToMessagesApi } from "@sps/social/relations/threads-to-messages/sdk/server";
 import { IModel as IEcommerceModuleProductsToFileStorageFiles } from "@sps/ecommerce/relations/products-to-file-storage-module-files/sdk/model";
 import { IModel as IFileStorageModuleFile } from "@sps/file-storage/models/file/sdk/model";
 import { api as notificationNotificationApi } from "@sps/notification/models/notification/sdk/server";
@@ -1249,10 +1252,14 @@ export class Service extends CRUDService<(typeof Table)["$inferSelect"]> {
     socialModuleMessage: ISocialModuleMessage;
     messageFromSocialModuleProfile: ISocialModuleProfile | null;
   }) {
+    let socialModuleThreadId: string | undefined;
+
     try {
       if (!RBAC_SECRET_KEY) {
         throw new Error("Configuration error. RBAC_SECRET_KEY is missing.");
       }
+
+      const secretKey = RBAC_SECRET_KEY;
 
       if (
         TELEGRAM_SERVICE_REQUIRED_SUBSCRIPTION_CHANNEL_ID &&
@@ -1267,6 +1274,18 @@ export class Service extends CRUDService<(typeof Table)["$inferSelect"]> {
       if (!props.socialModuleMessage.description) {
         throw new Error(
           "Validation error. 'props.socialModuleMessage.description' is empty.",
+        );
+      }
+
+      socialModuleThreadId = await this.resolveThreadIdForMessageInChat({
+        socialModuleChatId: props.socialModuleChat.id,
+        socialModuleMessageId: props.socialModuleMessage.id,
+        secretKey,
+      });
+
+      if (!socialModuleThreadId) {
+        throw new Error(
+          "Validation error. Failed to resolve social module thread",
         );
       }
 
@@ -1331,11 +1350,12 @@ export class Service extends CRUDService<(typeof Table)["$inferSelect"]> {
         requiredTelegramChannelSubscriptionRbacModuleRole &&
         !requiredTelegramChannelSubscriptionRbacModuleSubjectToRole
       ) {
-        return await rbacModuleSubjectApi.socialModuleProfileFindByIdChatFindByIdMessageCreate(
+        return await rbacModuleSubjectApi.socialModuleProfileFindByIdChatFindByIdThreadFindByIdMessageCreate(
           {
             id: props.rbacModuleSubject.id,
             socialModuleProfileId: props.shouldReplySocialModuleProfile.id,
             socialModuleChatId: props.socialModuleChat.id,
+            socialModuleThreadId,
             data: {
               description:
                 this.statusMessages
@@ -1363,11 +1383,12 @@ export class Service extends CRUDService<(typeof Table)["$inferSelect"]> {
       }
 
       if (!rbacModuleSubjectToPayableRoles?.length) {
-        return await rbacModuleSubjectApi.socialModuleProfileFindByIdChatFindByIdMessageCreate(
+        return await rbacModuleSubjectApi.socialModuleProfileFindByIdChatFindByIdThreadFindByIdMessageCreate(
           {
             id: props.rbacModuleSubject.id,
             socialModuleProfileId: props.shouldReplySocialModuleProfile.id,
             socialModuleChatId: props.socialModuleChat.id,
+            socialModuleThreadId,
             data: {
               description:
                 this.statusMessages.openRouterNotFoundSubscription.ru,
@@ -1436,21 +1457,40 @@ export class Service extends CRUDService<(typeof Table)["$inferSelect"]> {
             "Validation error. You do not have access to this resource because you have not 'subjectsToBillingModuleCurrencies' for pay that route",
           )
         ) {
-          await rbacModuleSubjectApi.socialModuleProfileFindByIdChatFindByIdMessageCreate(
-            {
-              id: props.rbacModuleSubject.id,
-              socialModuleProfileId: props.shouldReplySocialModuleProfile.id,
-              socialModuleChatId: props.socialModuleChat.id,
-              data: {
-                description: this.statusMessages.openRouterNotEnoughTokens.ru,
-              },
-              options: {
-                headers: {
-                  Authorization: "Bearer " + props.jwtToken,
+          if (socialModuleThreadId) {
+            await rbacModuleSubjectApi.socialModuleProfileFindByIdChatFindByIdThreadFindByIdMessageCreate(
+              {
+                id: props.rbacModuleSubject.id,
+                socialModuleProfileId: props.shouldReplySocialModuleProfile.id,
+                socialModuleChatId: props.socialModuleChat.id,
+                socialModuleThreadId,
+                data: {
+                  description: this.statusMessages.openRouterNotEnoughTokens.ru,
+                },
+                options: {
+                  headers: {
+                    Authorization: "Bearer " + props.jwtToken,
+                  },
                 },
               },
-            },
-          );
+            );
+          } else {
+            await rbacModuleSubjectApi.socialModuleProfileFindByIdChatFindByIdMessageCreate(
+              {
+                id: props.rbacModuleSubject.id,
+                socialModuleProfileId: props.shouldReplySocialModuleProfile.id,
+                socialModuleChatId: props.socialModuleChat.id,
+                data: {
+                  description: this.statusMessages.openRouterNotEnoughTokens.ru,
+                },
+                options: {
+                  headers: {
+                    Authorization: "Bearer " + props.jwtToken,
+                  },
+                },
+              },
+            );
+          }
           await this.telegramBotPremiumMessageWithKeyboardCreate({
             jwtToken: props.jwtToken,
             messageFromSocialModuleProfile:
@@ -1466,28 +1506,352 @@ export class Service extends CRUDService<(typeof Table)["$inferSelect"]> {
         }
       }
 
-      await rbacModuleSubjectApi.socialModuleProfileFindByIdChatFindByIdMessageCreate(
-        {
-          id: props.rbacModuleSubject.id,
-          socialModuleProfileId: props.shouldReplySocialModuleProfile.id,
-          socialModuleChatId: props.socialModuleChat.id,
-          data: {
-            description:
-              this.statusMessages.openRouterError.ru +
-              "\n`" +
-              (error as Error).message +
-              "`",
-          },
-          options: {
-            headers: {
-              Authorization: "Bearer " + props.jwtToken,
+      if (socialModuleThreadId) {
+        await rbacModuleSubjectApi.socialModuleProfileFindByIdChatFindByIdThreadFindByIdMessageCreate(
+          {
+            id: props.rbacModuleSubject.id,
+            socialModuleProfileId: props.shouldReplySocialModuleProfile.id,
+            socialModuleChatId: props.socialModuleChat.id,
+            socialModuleThreadId,
+            data: {
+              description:
+                this.statusMessages.openRouterError.ru +
+                "\n`" +
+                (error as Error).message +
+                "`",
+            },
+            options: {
+              headers: {
+                Authorization: "Bearer " + props.jwtToken,
+              },
             },
           },
-        },
-      );
+        );
+      } else {
+        await rbacModuleSubjectApi.socialModuleProfileFindByIdChatFindByIdMessageCreate(
+          {
+            id: props.rbacModuleSubject.id,
+            socialModuleProfileId: props.shouldReplySocialModuleProfile.id,
+            socialModuleChatId: props.socialModuleChat.id,
+            data: {
+              description:
+                this.statusMessages.openRouterError.ru +
+                "\n`" +
+                (error as Error).message +
+                "`",
+            },
+            options: {
+              headers: {
+                Authorization: "Bearer " + props.jwtToken,
+              },
+            },
+          },
+        );
+      }
 
       throw error;
     }
+  }
+
+  async resolveThreadIdForMessageInChat(props: {
+    socialModuleChatId: string;
+    socialModuleMessageId: string;
+    secretKey: string;
+  }): Promise<string> {
+    await this.normalizeChatThreadsAndMessageLinks({
+      socialModuleChatId: props.socialModuleChatId,
+      secretKey: props.secretKey,
+    });
+
+    const socialModuleChatsToThreads =
+      await this.socialModule.chatsToThreads.find({
+        params: {
+          filters: {
+            and: [
+              {
+                column: "chatId",
+                method: "eq",
+                value: props.socialModuleChatId,
+              },
+            ],
+          },
+        },
+      });
+
+    const chatThreadIds =
+      socialModuleChatsToThreads
+        ?.map((socialModuleChatToThread) => {
+          return socialModuleChatToThread.threadId;
+        })
+        .filter((threadId): threadId is string => Boolean(threadId)) || [];
+
+    const socialModuleThreadsToMessages =
+      await this.socialModule.threadsToMessages.find({
+        params: {
+          filters: {
+            and: [
+              {
+                column: "messageId",
+                method: "eq",
+                value: props.socialModuleMessageId,
+              },
+            ],
+          },
+        },
+      });
+
+    const messageThreadIds =
+      socialModuleThreadsToMessages
+        ?.map((socialModuleThreadToMessage) => {
+          return socialModuleThreadToMessage.threadId;
+        })
+        .filter((threadId): threadId is string => Boolean(threadId)) || [];
+
+    const chatThreadIdsSet = new Set(chatThreadIds);
+    const validMessageThreadIds = messageThreadIds.filter((threadId) => {
+      return chatThreadIdsSet.has(threadId);
+    });
+
+    if (validMessageThreadIds.length > 1) {
+      throw new Error(
+        "Validation error. Requested message is linked to multiple chat threads",
+      );
+    }
+
+    if (validMessageThreadIds.length === 1) {
+      return validMessageThreadIds[0];
+    }
+
+    if (messageThreadIds.length) {
+      throw new Error(
+        "Validation error. Requested message thread is not linked to the requested chat",
+      );
+    }
+
+    const socialModuleDefaultThread = await this.ensureDefaultThreadForChat({
+      socialModuleChatId: props.socialModuleChatId,
+      secretKey: props.secretKey,
+    });
+
+    await socialModuleThreadsToMessagesApi.create({
+      data: {
+        threadId: socialModuleDefaultThread.id,
+        messageId: props.socialModuleMessageId,
+      },
+      options: {
+        headers: {
+          "X-RBAC-SECRET-KEY": props.secretKey,
+        },
+      },
+    });
+
+    return socialModuleDefaultThread.id;
+  }
+
+  async normalizeChatThreadsAndMessageLinks(props: {
+    socialModuleChatId: string;
+    secretKey: string;
+  }) {
+    const socialModuleDefaultThread = await this.ensureDefaultThreadForChat({
+      socialModuleChatId: props.socialModuleChatId,
+      secretKey: props.secretKey,
+    });
+
+    const socialModuleChatsToMessages =
+      await this.socialModule.chatsToMessages.find({
+        params: {
+          filters: {
+            and: [
+              {
+                column: "chatId",
+                method: "eq",
+                value: props.socialModuleChatId,
+              },
+            ],
+          },
+        },
+      });
+
+    if (!socialModuleChatsToMessages?.length) {
+      return socialModuleDefaultThread.id;
+    }
+
+    const socialModuleMessageIds = Array.from(
+      new Set(
+        socialModuleChatsToMessages
+          .map((socialModuleChatToMessage) => {
+            return socialModuleChatToMessage.messageId;
+          })
+          .filter((messageId): messageId is string => Boolean(messageId)),
+      ),
+    );
+
+    if (!socialModuleMessageIds.length) {
+      return socialModuleDefaultThread.id;
+    }
+
+    const socialModuleChatsToThreads =
+      await this.socialModule.chatsToThreads.find({
+        params: {
+          filters: {
+            and: [
+              {
+                column: "chatId",
+                method: "eq",
+                value: props.socialModuleChatId,
+              },
+            ],
+          },
+        },
+      });
+
+    const chatThreadIdsSet = new Set(
+      socialModuleChatsToThreads
+        ?.map((socialModuleChatToThread) => {
+          return socialModuleChatToThread.threadId;
+        })
+        .filter((threadId): threadId is string => Boolean(threadId)) || [],
+    );
+    chatThreadIdsSet.add(socialModuleDefaultThread.id);
+
+    const socialModuleThreadsToMessages =
+      await this.socialModule.threadsToMessages.find({
+        params: {
+          filters: {
+            and: [
+              {
+                column: "messageId",
+                method: "inArray",
+                value: socialModuleMessageIds,
+              },
+            ],
+          },
+        },
+      });
+
+    const normalizedMessageIds = new Set(
+      socialModuleThreadsToMessages
+        ?.filter((socialModuleThreadToMessage) => {
+          if (!socialModuleThreadToMessage.messageId) {
+            return false;
+          }
+
+          if (!socialModuleThreadToMessage.threadId) {
+            return false;
+          }
+
+          return chatThreadIdsSet.has(socialModuleThreadToMessage.threadId);
+        })
+        .map((socialModuleThreadToMessage) => {
+          return socialModuleThreadToMessage.messageId;
+        }) || [],
+    );
+
+    const notNormalizedMessageIds = socialModuleMessageIds.filter(
+      (socialModuleMessageId) => {
+        return !normalizedMessageIds.has(socialModuleMessageId);
+      },
+    );
+
+    for (const socialModuleMessageId of notNormalizedMessageIds) {
+      await socialModuleThreadsToMessagesApi.create({
+        data: {
+          threadId: socialModuleDefaultThread.id,
+          messageId: socialModuleMessageId,
+        },
+        options: {
+          headers: {
+            "X-RBAC-SECRET-KEY": props.secretKey,
+          },
+        },
+      });
+    }
+
+    return socialModuleDefaultThread.id;
+  }
+
+  async ensureDefaultThreadForChat(props: {
+    socialModuleChatId: string;
+    secretKey: string;
+  }) {
+    const socialModuleChatsToThreads =
+      await this.socialModule.chatsToThreads.find({
+        params: {
+          filters: {
+            and: [
+              {
+                column: "chatId",
+                method: "eq",
+                value: props.socialModuleChatId,
+              },
+            ],
+          },
+        },
+      });
+
+    const threadIds =
+      socialModuleChatsToThreads
+        ?.map((socialModuleChatToThread) => {
+          return socialModuleChatToThread.threadId;
+        })
+        .filter((threadId): threadId is string => Boolean(threadId)) || [];
+
+    if (threadIds.length) {
+      const socialModuleThreads = await this.socialModule.thread.find({
+        params: {
+          filters: {
+            and: [
+              {
+                column: "id",
+                method: "inArray",
+                value: threadIds,
+              },
+            ],
+          },
+        },
+      });
+
+      const defaultSocialModuleThreads =
+        socialModuleThreads?.filter((socialModuleThread) => {
+          return socialModuleThread.variant === "default";
+        }) || [];
+
+      if (defaultSocialModuleThreads.length > 1) {
+        throw new Error(
+          "Validation error. Requested social-module chat has multiple default threads",
+        );
+      }
+
+      if (defaultSocialModuleThreads.length === 1) {
+        return defaultSocialModuleThreads[0];
+      }
+    }
+
+    const socialModuleDefaultThread = await socialModuleThreadApi.create({
+      data: {
+        variant: "default",
+      },
+      options: {
+        headers: {
+          "X-RBAC-SECRET-KEY": props.secretKey,
+        },
+      },
+    });
+
+    await socialModuleChatsToThreadsApi.create({
+      data: {
+        chatId: props.socialModuleChatId,
+        threadId: socialModuleDefaultThread.id,
+        variant: "default",
+      },
+      options: {
+        headers: {
+          "X-RBAC-SECRET-KEY": props.secretKey,
+        },
+      },
+    });
+
+    return socialModuleDefaultThread;
   }
 
   async extendedEcommerceModuleProduct(props: {

--- a/libs/modules/host/models/page/backend/app/api/src/lib/service/singlepage/index.ts
+++ b/libs/modules/host/models/page/backend/app/api/src/lib/service/singlepage/index.ts
@@ -105,16 +105,12 @@ export class Service extends CRUDService<(typeof Table)["$inferSelect"]> {
       throw new Error("Validation error. Invalid page size");
     }
 
-    const moduleData = await fetch(
-      `${API_SERVICE_URL}/api/${moduleName}/${modelName}`,
-      {
-        headers: {
-          "X-RBAC-SECRET-KEY": RBAC_SECRET_KEY as string,
-        },
-      },
-    ).then((res) => res.json());
-
-    const totalItems = moduleData?.data?.length || 0;
+    const moduleEntities = await this.fetchAllModuleEntities({
+      moduleName,
+      modelName,
+      secretKey: RBAC_SECRET_KEY,
+    });
+    const totalItems = moduleEntities.length;
     const totalPages = Math.ceil(totalItems / pageSizeNum);
 
     return [
@@ -157,26 +153,21 @@ export class Service extends CRUDService<(typeof Table)["$inferSelect"]> {
           const param = moduleSegment.split(".")[2];
           const moduleSegmentPaths: string[] = [];
 
-          const moduleData = await fetch(
-            `${API_SERVICE_URL}/api/${moduleName}/${modelName}`,
-            {
-              headers: {
-                "X-RBAC-SECRET-KEY": RBAC_SECRET_KEY,
-              },
-            },
-          ).then((res) => res.json());
+          const moduleEntities = await this.fetchAllModuleEntities({
+            moduleName,
+            modelName,
+            secretKey: RBAC_SECRET_KEY,
+          });
 
-          if (moduleData?.data?.length) {
-            moduleData.data.forEach((entity: unknown) => {
-              if (!entity?.[param]) {
-                throw new Error(
-                  `Not Found error. Entity with param ${param} not found`,
-                );
-              }
+          moduleEntities.forEach((entity: unknown) => {
+            if (!entity?.[param]) {
+              throw new Error(
+                `Not Found error. Entity with param ${param} not found`,
+              );
+            }
 
-              moduleSegmentPaths.push(entity[param]);
-            });
-          }
+            moduleSegmentPaths.push(entity[param]);
+          });
 
           saturatedSegments.push(moduleSegmentPaths);
           continue;
@@ -207,6 +198,28 @@ export class Service extends CRUDService<(typeof Table)["$inferSelect"]> {
     });
 
     return { ...result, urls };
+  }
+
+  private async fetchAllModuleEntities(props: {
+    moduleName: string;
+    modelName: string;
+    secretKey: string;
+  }): Promise<any[]> {
+    const response = await fetch(
+      `${API_SERVICE_URL}/api/${props.moduleName}/${props.modelName}`,
+      {
+        headers: {
+          "X-RBAC-SECRET-KEY": props.secretKey,
+        },
+      },
+    );
+    const payload = await response.json();
+
+    if (!Array.isArray(payload?.data)) {
+      return [];
+    }
+
+    return payload.data;
   }
 
   async urls() {

--- a/libs/modules/host/models/page/backend/repository/database/src/lib/data/3a3f793c-4a90-4cab-a35d-ec40848c34ed.json
+++ b/libs/modules/host/models/page/backend/repository/database/src/lib/data/3a3f793c-4a90-4cab-a35d-ec40848c34ed.json
@@ -1,0 +1,12 @@
+{
+  "id": "3a3f793c-4a90-4cab-a35d-ec40848c34ed",
+  "title": "Social Chat Thread Overview",
+  "url": "/social/chats/[social.chats.id]/threads/[social.threads.id]",
+  "description": "Description",
+  "createdAt": "2026-04-11T00:00:00.000Z",
+  "updatedAt": "2026-04-11T00:00:00.000Z",
+  "variant": "default",
+  "className": "",
+  "language": "en",
+  "adminTitle": "firm bronze pelican"
+}

--- a/libs/modules/host/relations/pages-to-layouts/backend/repository/database/src/lib/data/c67900a8-446f-4fdb-a70d-26069ff4eac0.json
+++ b/libs/modules/host/relations/pages-to-layouts/backend/repository/database/src/lib/data/c67900a8-446f-4fdb-a70d-26069ff4eac0.json
@@ -1,0 +1,10 @@
+{
+  "id": "c67900a8-446f-4fdb-a70d-26069ff4eac0",
+  "createdAt": "2026-04-11T00:00:00.000Z",
+  "updatedAt": "2026-04-11T00:00:00.000Z",
+  "variant": "default",
+  "orderIndex": 0,
+  "className": "",
+  "pageId": "3a3f793c-4a90-4cab-a35d-ec40848c34ed",
+  "layoutId": "58b127ed-dcd8-49db-a5dd-a10bef999a63"
+}

--- a/libs/modules/host/relations/pages-to-widgets/backend/repository/database/src/lib/data/2def9f11-e08c-478a-99ab-01d9e019d913.json
+++ b/libs/modules/host/relations/pages-to-widgets/backend/repository/database/src/lib/data/2def9f11-e08c-478a-99ab-01d9e019d913.json
@@ -1,0 +1,10 @@
+{
+  "id": "2def9f11-e08c-478a-99ab-01d9e019d913",
+  "createdAt": "2026-04-11T00:00:00.000Z",
+  "updatedAt": "2026-04-11T00:00:00.000Z",
+  "variant": "default",
+  "orderIndex": 1,
+  "className": "w-full lg:w-9/12",
+  "pageId": "3a3f793c-4a90-4cab-a35d-ec40848c34ed",
+  "widgetId": "c786cb5d-3c7a-4694-b86f-74eee0241995"
+}

--- a/libs/modules/host/relations/pages-to-widgets/backend/repository/database/src/lib/data/857edf62-ec9b-49dc-a392-0b76d571f792.json
+++ b/libs/modules/host/relations/pages-to-widgets/backend/repository/database/src/lib/data/857edf62-ec9b-49dc-a392-0b76d571f792.json
@@ -1,0 +1,10 @@
+{
+  "id": "857edf62-ec9b-49dc-a392-0b76d571f792",
+  "createdAt": "2026-04-11T00:00:00.000Z",
+  "updatedAt": "2026-04-11T00:00:00.000Z",
+  "variant": "default",
+  "orderIndex": 0,
+  "className": "w-full lg:w-3/12",
+  "pageId": "3a3f793c-4a90-4cab-a35d-ec40848c34ed",
+  "widgetId": "88510a3e-313e-4024-8a36-5aa245fa5cd9"
+}

--- a/libs/modules/host/relations/widgets-to-external-widgets/frontend/component/src/lib/singlepage/default/rbac/subject/singlepage/me/social-module-profile-chat-overview-default/ClientComponent.tsx
+++ b/libs/modules/host/relations/widgets-to-external-widgets/frontend/component/src/lib/singlepage/default/rbac/subject/singlepage/me/social-module-profile-chat-overview-default/ClientComponent.tsx
@@ -66,6 +66,9 @@ export function Component(props: IComponentProps) {
                                 language={props.language}
                                 socialModuleProfile={socialModuleProfile}
                                 socialModuleChatId={props.socialModuleChatId}
+                                socialModuleThreadId={
+                                  props.socialModuleThreadId
+                                }
                               />
                             );
                           },

--- a/libs/modules/host/relations/widgets-to-external-widgets/frontend/component/src/lib/singlepage/default/rbac/subject/singlepage/me/social-module-profile-chat-overview-default/Component.tsx
+++ b/libs/modules/host/relations/widgets-to-external-widgets/frontend/component/src/lib/singlepage/default/rbac/subject/singlepage/me/social-module-profile-chat-overview-default/Component.tsx
@@ -10,6 +10,7 @@ export function Component(props: IComponentProps) {
       language={props.language}
       variant={props.variant}
       socialModuleChatId={props.socialModuleChatId}
+      socialModuleThreadId={props.socialModuleThreadId}
     />
   );
 }

--- a/libs/modules/host/relations/widgets-to-external-widgets/frontend/component/src/lib/singlepage/default/rbac/subject/singlepage/me/social-module-profile-chat-overview-default/interface.ts
+++ b/libs/modules/host/relations/widgets-to-external-widgets/frontend/component/src/lib/singlepage/default/rbac/subject/singlepage/me/social-module-profile-chat-overview-default/interface.ts
@@ -5,4 +5,5 @@ export type IComponentProps = ISpsComponentBase & {
   language: string;
   variant: "me-social-module-profile-chat-overview-default";
   socialModuleChatId: ISocialModuleChat["id"];
+  socialModuleThreadId?: string;
 };

--- a/libs/modules/host/relations/widgets-to-external-widgets/frontend/component/src/lib/singlepage/default/social/widget/singlepage/chat/overview/default/Component.tsx
+++ b/libs/modules/host/relations/widgets-to-external-widgets/frontend/component/src/lib/singlepage/default/social/widget/singlepage/chat/overview/default/Component.tsx
@@ -16,12 +16,24 @@ export function Component(props: IComponentProps) {
         }
 
         return (
-          <RbacSubject
+          <HostModulePage
             isServer={props.isServer}
-            language={props.language}
-            variant="me-social-module-profile-chat-overview-default"
-            socialModuleChatId={socialModuleChatId}
-          />
+            variant="url-segment-value"
+            segment="social.threads.id"
+            url={props.url}
+          >
+            {({ data: socialModuleThreadId }) => {
+              return (
+                <RbacSubject
+                  isServer={props.isServer}
+                  language={props.language}
+                  variant="me-social-module-profile-chat-overview-default"
+                  socialModuleChatId={socialModuleChatId}
+                  socialModuleThreadId={socialModuleThreadId}
+                />
+              );
+            }}
+          </HostModulePage>
         );
       }}
     </HostModulePage>

--- a/libs/modules/rbac/models/subject/backend/app/api/src/lib/bootstrap.ts
+++ b/libs/modules/rbac/models/subject/backend/app/api/src/lib/bootstrap.ts
@@ -51,6 +51,8 @@ import { Repository as SocialProfileRepository } from "@sps/social/models/profil
 import { Configuration as SocialProfileConfiguration } from "@sps/social/models/profile/backend/app/api/src/lib/configuration";
 import { Repository as SocialChatRepository } from "@sps/social/models/chat/backend/app/api/src/lib/repository";
 import { Configuration as SocialChatConfiguration } from "@sps/social/models/chat/backend/app/api/src/lib/configuration";
+import { Repository as SocialThreadRepository } from "@sps/social/models/thread/backend/app/api/src/lib/repository";
+import { Configuration as SocialThreadConfiguration } from "@sps/social/models/thread/backend/app/api/src/lib/configuration";
 import { Repository as SocialMessageRepository } from "@sps/social/models/message/backend/app/api/src/lib/repository";
 import { Configuration as SocialMessageConfiguration } from "@sps/social/models/message/backend/app/api/src/lib/configuration";
 import { Repository as SocialActionRepository } from "@sps/social/models/action/backend/app/api/src/lib/repository";
@@ -69,8 +71,12 @@ import { Repository as SocialProfilesToAttributesRepository } from "@sps/social/
 import { Configuration as SocialProfilesToAttributesConfiguration } from "@sps/social/relations/profiles-to-attributes/backend/app/api/src/lib/configuration";
 import { Repository as SocialChatsToMessagesRepository } from "@sps/social/relations/chats-to-messages/backend/app/api/src/lib/repository";
 import { Configuration as SocialChatsToMessagesConfiguration } from "@sps/social/relations/chats-to-messages/backend/app/api/src/lib/configuration";
+import { Repository as SocialChatsToThreadsRepository } from "@sps/social/relations/chats-to-threads/backend/app/api/src/lib/repository";
+import { Configuration as SocialChatsToThreadsConfiguration } from "@sps/social/relations/chats-to-threads/backend/app/api/src/lib/configuration";
 import { Repository as SocialChatsToActionsRepository } from "@sps/social/relations/chats-to-actions/backend/app/api/src/lib/repository";
 import { Configuration as SocialChatsToActionsConfiguration } from "@sps/social/relations/chats-to-actions/backend/app/api/src/lib/configuration";
+import { Repository as SocialThreadsToMessagesRepository } from "@sps/social/relations/threads-to-messages/backend/app/api/src/lib/repository";
+import { Configuration as SocialThreadsToMessagesConfiguration } from "@sps/social/relations/threads-to-messages/backend/app/api/src/lib/configuration";
 import { Repository as SocialMessagesToFileStorageModuleFilesRepository } from "@sps/social/relations/messages-to-file-storage-module-files/backend/app/api/src/lib/repository";
 import { Configuration as SocialMessagesToFileStorageModuleFilesConfiguration } from "@sps/social/relations/messages-to-file-storage-module-files/backend/app/api/src/lib/configuration";
 import { Repository as SocialAttributeKeysToAttributesRepository } from "@sps/social/relations/attribute-keys-to-attributes/backend/app/api/src/lib/repository";
@@ -161,6 +167,9 @@ const bindings = new ContainerModule((bind: interfaces.Bind) => {
         chat: new CRUDService<any>(
           new SocialChatRepository(new SocialChatConfiguration()),
         ),
+        thread: new CRUDService<any>(
+          new SocialThreadRepository(new SocialThreadConfiguration()),
+        ),
         message: new CRUDService<any>(
           new SocialMessageRepository(new SocialMessageConfiguration()),
         ),
@@ -200,9 +209,19 @@ const bindings = new ContainerModule((bind: interfaces.Bind) => {
             new SocialChatsToMessagesConfiguration(),
           ),
         ),
+        chatsToThreads: new CRUDService<any>(
+          new SocialChatsToThreadsRepository(
+            new SocialChatsToThreadsConfiguration(),
+          ),
+        ),
         chatsToActions: new CRUDService<any>(
           new SocialChatsToActionsRepository(
             new SocialChatsToActionsConfiguration(),
+          ),
+        ),
+        threadsToMessages: new CRUDService<any>(
+          new SocialThreadsToMessagesRepository(
+            new SocialThreadsToMessagesConfiguration(),
           ),
         ),
         messagesToFileStorageModuleFiles: new CRUDService<any>(

--- a/libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/index.ts
+++ b/libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/index.ts
@@ -4,7 +4,10 @@ import { DI, RESTController } from "@sps/shared-backend-api";
 import { Table } from "@sps/rbac/models/subject/backend/repository/database";
 import { Service } from "../../service";
 import { Context } from "hono";
-import { RequestProfileSubjectIdOwner } from "../../../../../middlewares";
+import {
+  RequestProfileSubjectIdOwner,
+  RequestSubjectIdOwner,
+} from "../../../../../middlewares";
 
 import { Handler as AuthenticationMe } from "./authentication/me";
 import { Handler as AuthenticationIsAuthorized } from "./authentication/is-authorized";
@@ -55,6 +58,9 @@ import { Handler as SocialModuleProfileFindByIdChatCreate } from "./social-modul
 import { Handler as SocialModuleProfileFindByIdChatFindByIdDelete } from "./social-module/profile/find-by-id/chat/find-by-id/delete";
 import { Handler as SocialModuleProfileFindByIdChatFindByIdActionCreate } from "./social-module/profile/find-by-id/chat/find-by-id/action/create";
 import { Handler as SocialModuleProfileFindByIdChatFindByIdActionFind } from "./social-module/profile/find-by-id/chat/find-by-id/action/find";
+import { Handler as SocialModuleChatCreate } from "./social-module/chat/create";
+import { Handler as SocialModuleChatFindByIdThreadFind } from "./social-module/chat/find-by-id/thread/find";
+import { Handler as SocialModuleChatFindByIdThreadCreate } from "./social-module/chat/find-by-id/thread/create";
 import { Handler as TelegramBootstrap } from "./telegram/bootstrap";
 import { Handler as TelegramSyncMembership } from "./telegram/sync-membership";
 import { Handler as TelegramCheckoutFreeSubscription } from "./telegram/checkout-free-subscription";
@@ -290,6 +296,24 @@ export class Controller extends RESTController<(typeof Table)["$inferSelect"]> {
         middlewares: [new RequestProfileSubjectIdOwner().init()],
       },
       {
+        method: "POST",
+        path: "/:id/social-module/chats",
+        handler: this.socialModuleChatCreate,
+        middlewares: [new RequestSubjectIdOwner().init()],
+      },
+      {
+        method: "GET",
+        path: "/:id/social-module/chats/:socialModuleChatId/threads",
+        handler: this.socialModuleChatFindByIdThreadFind,
+        middlewares: [new RequestSubjectIdOwner().init()],
+      },
+      {
+        method: "POST",
+        path: "/:id/social-module/chats/:socialModuleChatId/threads",
+        handler: this.socialModuleChatFindByIdThreadCreate,
+        middlewares: [new RequestSubjectIdOwner().init()],
+      },
+      {
         method: "GET",
         path: "/:id/social-module/profiles/:socialModuleProfileId/chats/:socialModuleChatId/messages",
         handler: this.socialModuleProfileFindByIdChatFindByIdMessageFind,
@@ -299,6 +323,21 @@ export class Controller extends RESTController<(typeof Table)["$inferSelect"]> {
         method: "POST",
         path: "/:id/social-module/profiles/:socialModuleProfileId/chats/:socialModuleChatId/messages",
         handler: this.socialModuleProfileFindByIdChatFindByIdMessageCreate,
+        middlewares: [new RequestProfileSubjectIdOwner().init()],
+      },
+      {
+        method: "GET",
+        path: "/:id/social-module/profiles/:socialModuleProfileId/chats/:socialModuleChatId/threads/:socialModuleThreadId/messages",
+        handler:
+          this.socialModuleProfileFindByIdChatFindByIdThreadFindByIdMessageFind,
+        middlewares: [new RequestProfileSubjectIdOwner().init()],
+      },
+      {
+        method: "POST",
+        path: "/:id/social-module/profiles/:socialModuleProfileId/chats/:socialModuleChatId/threads/:socialModuleThreadId/messages",
+        handler:
+          this
+            .socialModuleProfileFindByIdChatFindByIdThreadFindByIdMessageCreate,
         middlewares: [new RequestProfileSubjectIdOwner().init()],
       },
       {
@@ -543,6 +582,30 @@ export class Controller extends RESTController<(typeof Table)["$inferSelect"]> {
     );
   }
 
+  async socialModuleChatCreate(c: Context, next: any): Promise<Response> {
+    return new SocialModuleChatCreate(this.service).execute(c, next);
+  }
+
+  async socialModuleChatFindByIdThreadFind(
+    c: Context,
+    next: any,
+  ): Promise<Response> {
+    return new SocialModuleChatFindByIdThreadFind(this.service).execute(
+      c,
+      next,
+    );
+  }
+
+  async socialModuleChatFindByIdThreadCreate(
+    c: Context,
+    next: any,
+  ): Promise<Response> {
+    return new SocialModuleChatFindByIdThreadCreate(this.service).execute(
+      c,
+      next,
+    );
+  }
+
   async socialModuleProfileFindByIdChatFindByIdMessageFind(
     c: Context,
     next: any,
@@ -553,6 +616,24 @@ export class Controller extends RESTController<(typeof Table)["$inferSelect"]> {
   }
 
   async socialModuleProfileFindByIdChatFindByIdMessageCreate(
+    c: Context,
+    next: any,
+  ): Promise<Response> {
+    return new SocialModuleProfileFindByIdChatFindByIdMessageCreate(
+      this.service,
+    ).execute(c, next);
+  }
+
+  async socialModuleProfileFindByIdChatFindByIdThreadFindByIdMessageFind(
+    c: Context,
+    next: any,
+  ): Promise<Response> {
+    return new SocialModuleProfileFindByIdChatFindByIdMessageFind(
+      this.service,
+    ).execute(c, next);
+  }
+
+  async socialModuleProfileFindByIdChatFindByIdThreadFindByIdMessageCreate(
     c: Context,
     next: any,
   ): Promise<Response> {

--- a/libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/chat/create.ts
+++ b/libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/chat/create.ts
@@ -1,7 +1,7 @@
 import { RBAC_JWT_SECRET } from "@sps/shared-utils";
 import { Context } from "hono";
 import { HTTPException } from "hono/http-exception";
-import { Service } from "../../../../../../service";
+import { Service } from "../../../../service";
 import { getHttpErrorType } from "@sps/backend-utils";
 
 export class Handler {
@@ -21,23 +21,6 @@ export class Handler {
 
       if (!id) {
         throw new Error("Validation error. No id provided");
-      }
-
-      const socialModuleProfileId = c.req.param("socialModuleProfileId");
-
-      if (!socialModuleProfileId) {
-        throw new Error("Validation error. No socialModuleProfileId provided");
-      }
-
-      const socialModuleProfile =
-        await this.service.socialModule.profile.findById({
-          id: socialModuleProfileId,
-        });
-
-      if (!socialModuleProfile) {
-        throw new Error(
-          "Not found error. Requested social-module profile not found",
-        );
       }
 
       const body = await c.req.parseBody();
@@ -63,9 +46,8 @@ export class Handler {
         await this.service.socialModuleChatLifecycleCreateChatWithDefaultThread(
           {
             subjectId: id,
-            requestedSocialModuleProfileId: socialModuleProfileId,
-            autoBootstrapProfile: false,
             data,
+            autoBootstrapProfile: true,
           },
         );
 

--- a/libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/chat/find-by-id/thread/create.ts
+++ b/libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/chat/find-by-id/thread/create.ts
@@ -1,8 +1,10 @@
-import { RBAC_JWT_SECRET } from "@sps/shared-utils";
+import { RBAC_JWT_SECRET, RBAC_SECRET_KEY } from "@sps/shared-utils";
 import { Context } from "hono";
 import { HTTPException } from "hono/http-exception";
 import { Service } from "../../../../../../service";
 import { getHttpErrorType } from "@sps/backend-utils";
+import { api as socialModuleThreadApi } from "@sps/social/models/thread/sdk/server";
+import { api as socialModuleChatsToThreadsApi } from "@sps/social/relations/chats-to-threads/sdk/server";
 
 export class Handler {
   service: Service;
@@ -17,28 +19,24 @@ export class Handler {
         throw new Error("Configuration error. RBAC_JWT_SECRET not set");
       }
 
+      const secretKey = this.getRequiredSecretKey();
+
       const id = c.req.param("id");
 
       if (!id) {
         throw new Error("Validation error. No id provided");
       }
 
-      const socialModuleProfileId = c.req.param("socialModuleProfileId");
+      const socialModuleChatId = c.req.param("socialModuleChatId");
 
-      if (!socialModuleProfileId) {
-        throw new Error("Validation error. No socialModuleProfileId provided");
+      if (!socialModuleChatId) {
+        throw new Error("Validation error. No socialModuleChatId provided");
       }
 
-      const socialModuleProfile =
-        await this.service.socialModule.profile.findById({
-          id: socialModuleProfileId,
-        });
-
-      if (!socialModuleProfile) {
-        throw new Error(
-          "Not found error. Requested social-module profile not found",
-        );
-      }
+      await this.service.socialModuleChatLifecycleAssertSubjectOwnsChat({
+        subjectId: id,
+        socialModuleChatId,
+      });
 
       const body = await c.req.parseBody();
 
@@ -59,24 +57,43 @@ export class Handler {
         );
       }
 
-      const { socialModuleChat } =
-        await this.service.socialModuleChatLifecycleCreateChatWithDefaultThread(
-          {
-            subjectId: id,
-            requestedSocialModuleProfileId: socialModuleProfileId,
-            autoBootstrapProfile: false,
-            data,
+      const socialModuleThread = await socialModuleThreadApi.create({
+        data: {
+          ...data,
+        },
+        options: {
+          headers: {
+            "X-RBAC-SECRET-KEY": secretKey,
           },
-        );
+        },
+      });
+
+      await socialModuleChatsToThreadsApi.create({
+        data: {
+          chatId: socialModuleChatId,
+          threadId: socialModuleThread.id,
+        },
+        options: {
+          headers: {
+            "X-RBAC-SECRET-KEY": secretKey,
+          },
+        },
+      });
 
       return c.json({
-        data: {
-          socialModuleChat,
-        },
+        data: socialModuleThread,
       });
     } catch (error: any) {
       const { status, message, details } = getHttpErrorType(error);
       throw new HTTPException(status, { message, cause: details });
     }
+  }
+
+  getRequiredSecretKey(): string {
+    if (!RBAC_SECRET_KEY) {
+      throw new Error("Configuration error. RBAC_SECRET_KEY not set");
+    }
+
+    return RBAC_SECRET_KEY;
   }
 }

--- a/libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/chat/find-by-id/thread/find.ts
+++ b/libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/chat/find-by-id/thread/find.ts
@@ -1,0 +1,91 @@
+import { RBAC_JWT_SECRET } from "@sps/shared-utils";
+import { Context } from "hono";
+import { HTTPException } from "hono/http-exception";
+import { Service } from "../../../../../../service";
+import { getHttpErrorType } from "@sps/backend-utils";
+
+export class Handler {
+  service: Service;
+
+  constructor(service: Service) {
+    this.service = service;
+  }
+
+  async execute(c: Context, next: any): Promise<Response> {
+    try {
+      if (!RBAC_JWT_SECRET) {
+        throw new Error("Configuration error. RBAC_JWT_SECRET not set");
+      }
+
+      const id = c.req.param("id");
+
+      if (!id) {
+        throw new Error("Validation error. No id provided");
+      }
+
+      const socialModuleChatId = c.req.param("socialModuleChatId");
+
+      if (!socialModuleChatId) {
+        throw new Error("Validation error. No socialModuleChatId provided");
+      }
+
+      await this.service.socialModuleChatLifecycleAssertSubjectOwnsChat({
+        subjectId: id,
+        socialModuleChatId,
+      });
+
+      const parsedQuery = c.get("parsedQuery");
+      const limit = parsedQuery?.limit || 100;
+      const offset = parsedQuery?.offset || 0;
+      const orderBy = parsedQuery?.orderBy;
+
+      const socialModuleChatsToThreads =
+        await this.service.socialModule.chatsToThreads.find({
+          params: {
+            filters: {
+              and: [
+                {
+                  column: "chatId",
+                  method: "eq",
+                  value: socialModuleChatId,
+                },
+              ],
+            },
+            limit,
+            offset,
+            orderBy,
+          },
+        });
+
+      if (!socialModuleChatsToThreads?.length) {
+        return c.json({
+          data: [],
+        });
+      }
+
+      const socialModuleThreads = await this.service.socialModule.thread.find({
+        params: {
+          filters: {
+            and: [
+              {
+                column: "id",
+                method: "inArray",
+                value: socialModuleChatsToThreads.map((chatToThread) => {
+                  return chatToThread.threadId;
+                }),
+              },
+            ],
+          },
+          orderBy,
+        },
+      });
+
+      return c.json({
+        data: socialModuleThreads,
+      });
+    } catch (error: any) {
+      const { status, message, details } = getHttpErrorType(error);
+      throw new HTTPException(status, { message, cause: details });
+    }
+  }
+}

--- a/libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/find-by-id/index.ts
+++ b/libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/find-by-id/index.ts
@@ -33,10 +33,52 @@ export class Handler {
         throw new Error("Validation error. No socialModuleProfileId provided");
       }
 
+      const subjectToSocialModuleProfiles =
+        await this.service.subjectsToSocialModuleProfiles.find({
+          params: {
+            filters: {
+              and: [
+                {
+                  column: "subjectId",
+                  method: "eq",
+                  value: id,
+                },
+                {
+                  column: "socialModuleProfileId",
+                  method: "eq",
+                  value: socialModuleProfileId,
+                },
+              ],
+            },
+          },
+        });
+
+      if (!subjectToSocialModuleProfiles?.length) {
+        throw new Error(
+          "Authorization error. Requested social-module profile does not belong to subject",
+        );
+      }
+
       const socialModuleChatId = c.req.param("socialModuleChatId");
 
       if (!socialModuleChatId) {
         throw new Error("Validation error. No socialModuleChatId provided");
+      }
+
+      if (await this.isSubjectAdmin(id)) {
+        const socialModuleChat = await this.service.socialModule.chat.findById({
+          id: socialModuleChatId,
+        });
+
+        if (!socialModuleChat) {
+          throw new Error(
+            "Not found error. Requested social-module chat not found",
+          );
+        }
+
+        return c.json({
+          data: socialModuleChat,
+        });
       }
 
       const socialModuleProfilesToChats =
@@ -82,5 +124,52 @@ export class Handler {
       const { status, message, details } = getHttpErrorType(error);
       throw new HTTPException(status, { message, cause: details });
     }
+  }
+
+  private async isSubjectAdmin(subjectId: string): Promise<boolean> {
+    const subjectsToRoles = await this.service.subjectsToRoles.find({
+      params: {
+        filters: {
+          and: [
+            {
+              column: "subjectId",
+              method: "eq",
+              value: subjectId,
+            },
+          ],
+        },
+      },
+    });
+
+    const roleIds =
+      subjectsToRoles
+        ?.map((subjectToRole) => {
+          return subjectToRole.roleId;
+        })
+        .filter((roleId): roleId is string => Boolean(roleId)) || [];
+
+    if (!roleIds.length) {
+      return false;
+    }
+
+    const roles = await this.service.role.find({
+      params: {
+        filters: {
+          and: [
+            {
+              column: "id",
+              method: "inArray",
+              value: roleIds,
+            },
+          ],
+        },
+      },
+    });
+
+    return Boolean(
+      roles?.find((role) => {
+        return role.slug === "admin";
+      }),
+    );
   }
 }

--- a/libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/find-by-id/message/create.ts
+++ b/libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/find-by-id/message/create.ts
@@ -5,6 +5,7 @@ import { Service } from "../../../../../../../../service";
 import { api as socialModuleProfilesToMessagesApi } from "@sps/social/relations/profiles-to-messages/sdk/server";
 import { api as socialModuleMessageApi } from "@sps/social/models/message/sdk/server";
 import { api as socialModuleChatsToMessagesApi } from "@sps/social/relations/chats-to-messages/sdk/server";
+import { api as socialModuleThreadsToMessagesApi } from "@sps/social/relations/threads-to-messages/sdk/server";
 import { api } from "@sps/rbac/models/subject/sdk/server";
 import { api as socialModuleMessagesToFileStorageModuleFilesApi } from "@sps/social/relations/messages-to-file-storage-module-files/sdk/server";
 import { IModel as ISocialModuleMessagesToFileStorageModuleFile } from "@sps/social/relations/messages-to-file-storage-module-files/sdk/model";
@@ -47,6 +48,14 @@ export class Handler {
         throw new Error("Validation error. No socialModuleChatId provided");
       }
 
+      const socialModuleThreadIdFromPath = c.req.param("socialModuleThreadId");
+
+      await this.assertProfileCanAccessChat({
+        subjectId: id,
+        socialModuleProfileId,
+        socialModuleChatId,
+      });
+
       const formData = await c.req.formData();
       const dataField = formData.get("data");
 
@@ -74,6 +83,20 @@ export class Handler {
         );
       }
 
+      const requestedThreadId =
+        typeof parsedBody.data?.threadId === "string"
+          ? parsedBody.data.threadId.trim()
+          : "";
+      const socialModuleThreadId = await this.resolveTargetThreadId({
+        socialModuleChatId,
+        pathSocialModuleThreadId: socialModuleThreadIdFromPath || undefined,
+        requestedThreadId: requestedThreadId || undefined,
+      });
+
+      if (parsedBody.data && "threadId" in parsedBody.data) {
+        delete parsedBody.data.threadId;
+      }
+
       const sourceSystemId =
         typeof parsedBody.data?.sourceSystemId === "string"
           ? parsedBody.data.sourceSystemId.trim()
@@ -83,6 +106,7 @@ export class Handler {
         const existingMessage = await this.findExistingBySourceSystemId({
           sourceSystemId,
           socialModuleChatId,
+          socialModuleThreadId,
         });
 
         if (existingMessage) {
@@ -113,6 +137,18 @@ export class Handler {
         data: {
           messageId: socialMouleMessage.id,
           chatId: socialModuleChatId,
+        },
+        options: {
+          headers: {
+            "X-RBAC-SECRET-KEY": RBAC_SECRET_KEY,
+          },
+        },
+      });
+
+      await socialModuleThreadsToMessagesApi.create({
+        data: {
+          messageId: socialMouleMessage.id,
+          threadId: socialModuleThreadId,
         },
         options: {
           headers: {
@@ -509,6 +545,7 @@ export class Handler {
   async findExistingBySourceSystemId(props: {
     sourceSystemId: string;
     socialModuleChatId: string;
+    socialModuleThreadId: string;
   }): Promise<ISocialModuleMessage | undefined> {
     const messages = await this.service.socialModule.message.find({
       params: {
@@ -562,8 +599,152 @@ export class Handler {
       return;
     }
 
-    const messageIdsSet = new Set(messageIdsInChat);
+    const threadsToMessages =
+      await this.service.socialModule.threadsToMessages.find({
+        params: {
+          filters: {
+            and: [
+              {
+                column: "threadId",
+                method: "eq",
+                value: props.socialModuleThreadId,
+              },
+              {
+                column: "messageId",
+                method: "inArray",
+                value: messageIdsInChat,
+              },
+            ],
+          },
+        },
+      });
+
+    if (!threadsToMessages?.length) {
+      return;
+    }
+
+    const messageIdsSet = new Set(
+      threadsToMessages
+        .map((threadToMessage) => threadToMessage.messageId)
+        .filter((id): id is string => Boolean(id)),
+    );
 
     return messages.find((message) => messageIdsSet.has(message.id));
+  }
+
+  async resolveTargetThreadId(props: {
+    socialModuleChatId: string;
+    pathSocialModuleThreadId?: string;
+    requestedThreadId?: string;
+  }): Promise<string> {
+    if (props.pathSocialModuleThreadId) {
+      if (
+        props.requestedThreadId &&
+        props.requestedThreadId !== props.pathSocialModuleThreadId
+      ) {
+        throw new Error(
+          "Validation error. threadId in path does not match threadId in payload",
+        );
+      }
+
+      await this.service.socialModuleChatLifecycleAssertThreadBelongsToChat({
+        socialModuleChatId: props.socialModuleChatId,
+        socialModuleThreadId: props.pathSocialModuleThreadId,
+      });
+
+      return props.pathSocialModuleThreadId;
+    }
+
+    if (props.requestedThreadId) {
+      throw new Error(
+        "Validation error. threadId must be provided in route path",
+      );
+    }
+
+    const defaultThread =
+      await this.service.socialModuleChatLifecycleEnsureDefaultThreadForChat({
+        socialModuleChatId: props.socialModuleChatId,
+      });
+
+    return defaultThread.id;
+  }
+
+  async assertProfileCanAccessChat(props: {
+    subjectId: string;
+    socialModuleProfileId: string;
+    socialModuleChatId: string;
+  }) {
+    const socialModuleProfilesToChats =
+      await this.service.socialModule.profilesToChats.find({
+        params: {
+          filters: {
+            and: [
+              {
+                column: "profileId",
+                method: "eq",
+                value: props.socialModuleProfileId,
+              },
+              {
+                column: "chatId",
+                method: "eq",
+                value: props.socialModuleChatId,
+              },
+            ],
+          },
+        },
+      });
+
+    if (socialModuleProfilesToChats?.length) {
+      return;
+    }
+
+    if (await this.isSubjectAdmin(props.subjectId)) {
+      return;
+    }
+
+    throw new Error(
+      "Authorization error. Requested social-module chat does not belong to profile",
+    );
+  }
+
+  async isSubjectAdmin(subjectId: string): Promise<boolean> {
+    const subjectsToRoles = await this.service.subjectsToRoles.find({
+      params: {
+        filters: {
+          and: [
+            {
+              column: "subjectId",
+              method: "eq",
+              value: subjectId,
+            },
+          ],
+        },
+      },
+    });
+
+    const roleIds =
+      subjectsToRoles
+        ?.map((subjectToRole) => subjectToRole.roleId)
+        .filter((roleId): roleId is string => Boolean(roleId)) || [];
+
+    if (!roleIds.length) {
+      return false;
+    }
+
+    const roles = await this.service.role.find({
+      params: {
+        filters: {
+          and: [
+            {
+              column: "id",
+              method: "inArray",
+              value: roleIds,
+            },
+          ],
+        },
+      },
+    });
+
+    return Boolean(roles?.find((role) => role.slug === "admin"));
   }
 }

--- a/libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/find-by-id/message/find.ts
+++ b/libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/find-by-id/message/find.ts
@@ -39,10 +39,73 @@ export class Handler {
         throw new Error("Validation error. No socialModuleChatId provided");
       }
 
+      const socialModuleThreadId = c.req.param("socialModuleThreadId");
+
+      await this.assertProfileCanAccessChat({
+        subjectId: id,
+        socialModuleProfileId,
+        socialModuleChatId,
+      });
+
       const parsedQuery = c.get("parsedQuery");
       const limit = parsedQuery?.limit || 100;
       const offset = parsedQuery?.offset || 0;
       const orderBy = parsedQuery?.orderBy;
+
+      if (socialModuleThreadId) {
+        await this.service.socialModuleChatLifecycleAssertThreadBelongsToChat({
+          socialModuleChatId,
+          socialModuleThreadId,
+        });
+
+        const socialModuleThreadsToMessages =
+          await this.service.socialModule.threadsToMessages.find({
+            params: {
+              filters: {
+                and: [
+                  {
+                    column: "threadId",
+                    method: "eq",
+                    value: socialModuleThreadId,
+                  },
+                ],
+              },
+              limit,
+              offset,
+              orderBy,
+            },
+          });
+
+        if (!socialModuleThreadsToMessages?.length) {
+          return c.json({
+            data: [],
+          });
+        }
+
+        const socialModuleMessages =
+          await this.service.socialModule.message.find({
+            params: {
+              filters: {
+                and: [
+                  {
+                    column: "id",
+                    method: "inArray",
+                    value: socialModuleThreadsToMessages.map(
+                      (socialModuleThreadsToMessage) => {
+                        return socialModuleThreadsToMessage.messageId;
+                      },
+                    ),
+                  },
+                ],
+              },
+              orderBy,
+            },
+          });
+
+        return c.json({
+          data: socialModuleMessages,
+        });
+      }
 
       const socialModuleChatsToMessages =
         await this.service.socialModule.chatsToMessages.find({
@@ -96,5 +159,84 @@ export class Handler {
       const { status, message, details } = getHttpErrorType(error);
       throw new HTTPException(status, { message, cause: details });
     }
+  }
+
+  async assertProfileCanAccessChat(props: {
+    subjectId: string;
+    socialModuleProfileId: string;
+    socialModuleChatId: string;
+  }) {
+    const socialModuleProfilesToChats =
+      await this.service.socialModule.profilesToChats.find({
+        params: {
+          filters: {
+            and: [
+              {
+                column: "profileId",
+                method: "eq",
+                value: props.socialModuleProfileId,
+              },
+              {
+                column: "chatId",
+                method: "eq",
+                value: props.socialModuleChatId,
+              },
+            ],
+          },
+        },
+      });
+
+    if (socialModuleProfilesToChats?.length) {
+      return;
+    }
+
+    if (await this.isSubjectAdmin(props.subjectId)) {
+      return;
+    }
+
+    throw new Error(
+      "Authorization error. Requested social-module chat does not belong to profile",
+    );
+  }
+
+  async isSubjectAdmin(subjectId: string): Promise<boolean> {
+    const subjectsToRoles = await this.service.subjectsToRoles.find({
+      params: {
+        filters: {
+          and: [
+            {
+              column: "subjectId",
+              method: "eq",
+              value: subjectId,
+            },
+          ],
+        },
+      },
+    });
+
+    const roleIds =
+      subjectsToRoles
+        ?.map((subjectToRole) => subjectToRole.roleId)
+        .filter((roleId): roleId is string => Boolean(roleId)) || [];
+
+    if (!roleIds.length) {
+      return false;
+    }
+
+    const roles = await this.service.role.find({
+      params: {
+        filters: {
+          and: [
+            {
+              column: "id",
+              method: "inArray",
+              value: roleIds,
+            },
+          ],
+        },
+      },
+    });
+
+    return Boolean(roles?.find((role) => role.slug === "admin"));
   }
 }

--- a/libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/find-by-id/message/react-by-openrouter.ts
+++ b/libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/find-by-id/message/react-by-openrouter.ts
@@ -2,7 +2,6 @@ import {
   NEXT_PUBLIC_API_SERVICE_URL,
   RBAC_JWT_SECRET,
   RBAC_JWT_TOKEN_LIFETIME_IN_SECONDS,
-  RBAC_SECRET_KEY,
   telegramBotServiceMessages,
 } from "@sps/shared-utils";
 import { Context } from "hono";
@@ -327,10 +326,6 @@ export class Handler {
         throw new Error("Configuration error. RBAC_JWT_SECRET not set");
       }
 
-      if (!RBAC_SECRET_KEY) {
-        throw new Error("Configuration error. RBAC_SECRET_KEY not set");
-      }
-
       const id = c.req.param("id");
 
       if (!id) {
@@ -417,15 +412,20 @@ export class Handler {
         );
       }
 
-      const socialModuleChatToMessages =
-        await this.service.socialModule.chatsToMessages.find({
+      const socialModuleThreadId = await this.resolveThreadIdForMessageInChat({
+        socialModuleChatId,
+        socialModuleMessageId,
+      });
+
+      const socialModuleThreadToMessages =
+        await this.service.socialModule.threadsToMessages.find({
           params: {
             filters: {
               and: [
                 {
-                  column: "chatId",
+                  column: "threadId",
                   method: "eq",
-                  value: socialModuleChatId,
+                  value: socialModuleThreadId,
                 },
               ],
             },
@@ -451,7 +451,48 @@ export class Handler {
         );
       }
 
-      if (socialModuleChatToMessages?.length) {
+      if (socialModuleThreadToMessages?.length) {
+        const threadMessageIds = socialModuleThreadToMessages
+          .map((socialModuleThreadToMessage) => {
+            return socialModuleThreadToMessage.messageId;
+          })
+          .filter((messageId): messageId is string => Boolean(messageId));
+
+        const socialModuleChatToMessages = threadMessageIds.length
+          ? await this.service.socialModule.chatsToMessages.find({
+              params: {
+                filters: {
+                  and: [
+                    {
+                      column: "chatId",
+                      method: "eq",
+                      value: socialModuleChatId,
+                    },
+                    {
+                      column: "messageId",
+                      method: "inArray",
+                      value: threadMessageIds,
+                    },
+                  ],
+                },
+              },
+            })
+          : [];
+
+        const chatThreadMessageIds =
+          socialModuleChatToMessages
+            ?.map((socialModuleChatToMessage) => {
+              return socialModuleChatToMessage.messageId;
+            })
+            .filter((messageId): messageId is string => Boolean(messageId)) ||
+          [];
+
+        if (!chatThreadMessageIds.length) {
+          throw new Error(
+            "Validation error. No thread messages found in the requested chat",
+          );
+        }
+
         const socialModuleMessages =
           await this.service.socialModule.message.find({
             params: {
@@ -460,10 +501,7 @@ export class Handler {
                   {
                     column: "id",
                     method: "inArray",
-                    value: socialModuleChatToMessages.map(
-                      (socialModuleChatToMessage) =>
-                        socialModuleChatToMessage.messageId,
-                    ),
+                    value: chatThreadMessageIds,
                   },
                 ],
               },
@@ -665,19 +703,22 @@ export class Handler {
       const openRouter = new OpenRouter();
 
       const statusMessage =
-        await api.socialModuleProfileFindByIdChatFindByIdMessageCreate({
-          id: replyBySubject.id,
-          socialModuleProfileId: replyBySocialModuleProfile.id,
-          socialModuleChatId: socialModuleChatId,
-          data: {
-            description: this.statusMessages.openRouterStarted.ru,
-          },
-          options: {
-            headers: {
-              Authorization: "Bearer " + replyByJwt,
+        await api.socialModuleProfileFindByIdChatFindByIdThreadFindByIdMessageCreate(
+          {
+            id: replyBySubject.id,
+            socialModuleProfileId: replyBySocialModuleProfile.id,
+            socialModuleChatId: socialModuleChatId,
+            socialModuleThreadId,
+            data: {
+              description: this.statusMessages.openRouterStarted.ru,
+            },
+            options: {
+              headers: {
+                Authorization: "Bearer " + replyByJwt,
+              },
             },
           },
-        });
+        );
 
       await api.socialModuleProfileFindByIdChatFindByIdMessageUpdate({
         id: replyBySubject.id,
@@ -913,17 +954,20 @@ export class Handler {
       });
 
       const repliedSocialModuleMessage =
-        await api.socialModuleProfileFindByIdChatFindByIdMessageCreate({
-          id: replyBySubject.id,
-          socialModuleProfileId: replyBySocialModuleProfile.id,
-          socialModuleChatId: socialModuleChatId,
-          data: replyMessageData,
-          options: {
-            headers: {
-              Authorization: "Bearer " + replyByJwt,
+        await api.socialModuleProfileFindByIdChatFindByIdThreadFindByIdMessageCreate(
+          {
+            id: replyBySubject.id,
+            socialModuleProfileId: replyBySocialModuleProfile.id,
+            socialModuleChatId: socialModuleChatId,
+            socialModuleThreadId,
+            data: replyMessageData,
+            options: {
+              headers: {
+                Authorization: "Bearer " + replyByJwt,
+              },
             },
           },
-        });
+        );
 
       return c.json({
         data: {
@@ -936,6 +980,113 @@ export class Handler {
       const { status, message, details } = getHttpErrorType(error);
       throw new HTTPException(status, { message, cause: details });
     }
+  }
+
+  async resolveThreadIdForMessageInChat(props: {
+    socialModuleChatId: string;
+    socialModuleMessageId: string;
+  }): Promise<string> {
+    const socialModuleChatsToThreads =
+      await this.service.socialModule.chatsToThreads.find({
+        params: {
+          filters: {
+            and: [
+              {
+                column: "chatId",
+                method: "eq",
+                value: props.socialModuleChatId,
+              },
+            ],
+          },
+        },
+      });
+
+    const chatThreadIds =
+      socialModuleChatsToThreads
+        ?.map((socialModuleChatToThread) => {
+          return socialModuleChatToThread.threadId;
+        })
+        .filter((threadId): threadId is string => Boolean(threadId)) || [];
+
+    const socialModuleThreadsToMessages =
+      await this.service.socialModule.threadsToMessages.find({
+        params: {
+          filters: {
+            and: [
+              {
+                column: "messageId",
+                method: "eq",
+                value: props.socialModuleMessageId,
+              },
+            ],
+          },
+        },
+      });
+
+    const messageThreadIds =
+      socialModuleThreadsToMessages
+        ?.map((socialModuleThreadToMessage) => {
+          return socialModuleThreadToMessage.threadId;
+        })
+        .filter((threadId): threadId is string => Boolean(threadId)) || [];
+
+    const chatThreadIdsSet = new Set(chatThreadIds);
+    const validMessageThreadIds = messageThreadIds.filter((threadId) =>
+      chatThreadIdsSet.has(threadId),
+    );
+
+    if (validMessageThreadIds.length > 1) {
+      throw new Error(
+        "Validation error. Requested message is linked to multiple chat threads",
+      );
+    }
+
+    if (validMessageThreadIds.length === 1) {
+      return validMessageThreadIds[0];
+    }
+
+    if (messageThreadIds.length) {
+      throw new Error(
+        "Validation error. Requested message thread is not linked to the requested chat",
+      );
+    }
+
+    const socialModuleDefaultThread =
+      await this.service.socialModuleChatLifecycleEnsureDefaultThreadForChat({
+        socialModuleChatId: props.socialModuleChatId,
+      });
+
+    const existingThreadToMessageLinks =
+      await this.service.socialModule.threadsToMessages.find({
+        params: {
+          filters: {
+            and: [
+              {
+                column: "threadId",
+                method: "eq",
+                value: socialModuleDefaultThread.id,
+              },
+              {
+                column: "messageId",
+                method: "eq",
+                value: props.socialModuleMessageId,
+              },
+            ],
+          },
+          limit: 1,
+        },
+      });
+
+    if (!existingThreadToMessageLinks?.length) {
+      await this.service.socialModule.threadsToMessages.create({
+        data: {
+          threadId: socialModuleDefaultThread.id,
+          messageId: props.socialModuleMessageId,
+        },
+      });
+    }
+
+    return socialModuleDefaultThread.id;
   }
 
   private detectInputModalitiesFromContext(

--- a/libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/find.ts
+++ b/libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/find.ts
@@ -27,51 +27,6 @@ export class Handler {
         throw new Error("Validation error. No id provided");
       }
 
-      const subjectsToRoles = await this.service.subjectsToRoles.find({
-        params: {
-          filters: {
-            and: [
-              {
-                column: "subjectId",
-                method: "eq",
-                value: id,
-              },
-            ],
-          },
-        },
-      });
-
-      if (subjectsToRoles?.length) {
-        const roles = await this.service.role.find({
-          params: {
-            filters: {
-              and: [
-                {
-                  column: "id",
-                  method: "inArray",
-                  value: subjectsToRoles.map((e) => e.roleId),
-                },
-              ],
-            },
-          },
-        });
-
-        if (roles?.length) {
-          const hasAdminRole = roles.find((role) => role.slug === "admin");
-
-          if (hasAdminRole) {
-            const socialModuleChats =
-              await this.service.socialModule.chat.find();
-
-            return c.json({
-              data: socialModuleChats,
-            });
-          }
-        }
-      }
-
-      console.log("🚀 ~ execute ~ subjectsToRoles:", subjectsToRoles);
-
       const socialModuleProfileId = c.req.param("socialModuleProfileId");
 
       if (!socialModuleProfileId) {
@@ -89,10 +44,50 @@ export class Handler {
         );
       }
 
+      const subjectToSocialModuleProfiles =
+        await this.service.subjectsToSocialModuleProfiles.find({
+          params: {
+            filters: {
+              and: [
+                {
+                  column: "subjectId",
+                  method: "eq",
+                  value: id,
+                },
+                {
+                  column: "socialModuleProfileId",
+                  method: "eq",
+                  value: socialModuleProfileId,
+                },
+              ],
+            },
+          },
+        });
+
+      if (!subjectToSocialModuleProfiles?.length) {
+        throw new Error(
+          "Authorization error. Requested social-module profile does not belong to subject",
+        );
+      }
+
       const parsedQuery = c.get("parsedQuery");
       const limit = parsedQuery?.limit || 100;
       const offset = parsedQuery?.offset || 0;
       const orderBy = parsedQuery?.orderBy;
+
+      if (await this.isSubjectAdmin(id)) {
+        const socialModuleChats = await this.service.socialModule.chat.find({
+          params: {
+            limit,
+            offset,
+            orderBy,
+          },
+        });
+
+        return c.json({
+          data: socialModuleChats,
+        });
+      }
 
       const socialModuleProfilesToChats =
         await this.service.socialModule.profilesToChats.find({
@@ -143,5 +138,52 @@ export class Handler {
       const { status, message, details } = getHttpErrorType(error);
       throw new HTTPException(status, { message, cause: details });
     }
+  }
+
+  private async isSubjectAdmin(subjectId: string): Promise<boolean> {
+    const subjectsToRoles = await this.service.subjectsToRoles.find({
+      params: {
+        filters: {
+          and: [
+            {
+              column: "subjectId",
+              method: "eq",
+              value: subjectId,
+            },
+          ],
+        },
+      },
+    });
+
+    const roleIds =
+      subjectsToRoles
+        ?.map((subjectToRole) => {
+          return subjectToRole.roleId;
+        })
+        .filter((roleId): roleId is string => Boolean(roleId)) || [];
+
+    if (!roleIds.length) {
+      return false;
+    }
+
+    const roles = await this.service.role.find({
+      params: {
+        filters: {
+          and: [
+            {
+              column: "id",
+              method: "inArray",
+              value: roleIds,
+            },
+          ],
+        },
+      },
+    });
+
+    return Boolean(
+      roles?.find((role) => {
+        return role.slug === "admin";
+      }),
+    );
   }
 }

--- a/libs/modules/rbac/models/subject/backend/app/api/src/lib/di.ts
+++ b/libs/modules/rbac/models/subject/backend/app/api/src/lib/di.ts
@@ -3,6 +3,10 @@ export interface IReadService {
   findById: (props: { id: string }) => Promise<any>;
 }
 
+export interface ICreateService extends IReadService {
+  create: (props: { data: any }) => Promise<any>;
+}
+
 export interface IExtendedReadService extends IReadService {
   findByIdExtended: (props: { id: string }) => Promise<any>;
 }
@@ -23,6 +27,7 @@ export interface IEcommerceOrderReadService extends IExtendedReadService {
 export interface ISocialModule {
   profile: IReadService;
   chat: IReadService;
+  thread: IReadService;
   message: IReadService;
   action: IReadService;
   attribute: IReadService;
@@ -31,8 +36,10 @@ export interface ISocialModule {
   profilesToMessages: IReadService;
   profilesToActions: IReadService;
   profilesToAttributes: IReadService;
+  chatsToThreads: IReadService;
   chatsToMessages: IReadService;
   chatsToActions: IReadService;
+  threadsToMessages: ICreateService;
   messagesToFileStorageModuleFiles: IReadService;
   attributeKeysToAttributes: IReadService;
 }

--- a/libs/modules/rbac/models/subject/backend/app/api/src/lib/service/singlepage/index.ts
+++ b/libs/modules/rbac/models/subject/backend/app/api/src/lib/service/singlepage/index.ts
@@ -87,6 +87,9 @@ import {
   Service as TelegramCheckoutFreeSubscription,
   IExecuteProps as ITelegramCheckoutFreeSubscriptionExecuteProps,
 } from "./telegram/checkout-free-subscription";
+import { ChatLifecycleService } from "./social-module/chat-lifecycle";
+import { IModel as ISocialModuleChat } from "@sps/social/models/chat/sdk/model";
+import { IModel as ISocialModuleThread } from "@sps/social/models/thread/sdk/model";
 
 @injectable()
 export class Service extends CRUDService<(typeof Table)["$inferSelect"]> {
@@ -231,6 +234,42 @@ export class Service extends CRUDService<(typeof Table)["$inferSelect"]> {
     );
   }
 
+  async socialModuleChatLifecycleCreateChatWithDefaultThread(props: {
+    subjectId: string;
+    data: Partial<ISocialModuleChat>;
+    requestedSocialModuleProfileId?: string;
+    autoBootstrapProfile: boolean;
+  }) {
+    return this.getChatLifecycleService().createChatWithDefaultThread(props);
+  }
+
+  async socialModuleChatLifecycleAssertSubjectOwnsChat(props: {
+    subjectId: string;
+    socialModuleChatId: string;
+  }) {
+    return this.getChatLifecycleService().assertSubjectOwnsChat(props);
+  }
+
+  async socialModuleChatLifecycleResolveSubjectProfileIdInChat(props: {
+    subjectId: string;
+    socialModuleChatId: string;
+  }) {
+    return this.getChatLifecycleService().resolveSubjectProfileIdInChat(props);
+  }
+
+  async socialModuleChatLifecycleAssertThreadBelongsToChat(props: {
+    socialModuleChatId: string;
+    socialModuleThreadId: string;
+  }) {
+    return this.getChatLifecycleService().assertThreadBelongsToChat(props);
+  }
+
+  async socialModuleChatLifecycleEnsureDefaultThreadForChat(props: {
+    socialModuleChatId: string;
+  }): Promise<ISocialModuleThread> {
+    return this.getChatLifecycleService().ensureDefaultThreadForChat(props);
+  }
+
   async billRoute(props: IBillRouteProps) {
     return this.billRouteService.execute(props);
   }
@@ -269,5 +308,9 @@ export class Service extends CRUDService<(typeof Table)["$inferSelect"]> {
       billingModule: this.billingModule,
       subjectsToEcommerceModuleOrders: this.subjectsToEcommerceModuleOrders,
     }).execute(props);
+  }
+
+  private getChatLifecycleService() {
+    return new ChatLifecycleService(this);
   }
 }

--- a/libs/modules/rbac/models/subject/backend/app/api/src/lib/service/singlepage/social-module/chat-lifecycle.ts
+++ b/libs/modules/rbac/models/subject/backend/app/api/src/lib/service/singlepage/social-module/chat-lifecycle.ts
@@ -1,0 +1,539 @@
+import { api as subjectsToSocialModuleProfilesApi } from "@sps/rbac/relations/subjects-to-social-module-profiles/sdk/server";
+import { api as socialModuleChatApi } from "@sps/social/models/chat/sdk/server";
+import { IModel as ISocialModuleChat } from "@sps/social/models/chat/sdk/model";
+import { api as socialModuleProfileApi } from "@sps/social/models/profile/sdk/server";
+import { api as socialModuleThreadApi } from "@sps/social/models/thread/sdk/server";
+import { IModel as ISocialModuleThread } from "@sps/social/models/thread/sdk/model";
+import { api as socialModuleChatsToThreadsApi } from "@sps/social/relations/chats-to-threads/sdk/server";
+import { api as socialModuleProfilesToChatsApi } from "@sps/social/relations/profiles-to-chats/sdk/server";
+import { RBAC_SECRET_KEY } from "@sps/shared-utils";
+import { Service } from "../index";
+
+export class ChatLifecycleService {
+  private service: Service;
+
+  constructor(service: Service) {
+    this.service = service;
+  }
+
+  async createChatWithDefaultThread(props: {
+    subjectId: string;
+    data: Partial<ISocialModuleChat>;
+    requestedSocialModuleProfileId?: string;
+    autoBootstrapProfile: boolean;
+  }): Promise<{
+    socialModuleChat: ISocialModuleChat;
+    socialModuleProfileId: string;
+    socialModuleDefaultThread: ISocialModuleThread;
+  }> {
+    if (!RBAC_SECRET_KEY) {
+      throw new Error("Configuration error. RBAC_SECRET_KEY not set");
+    }
+
+    const socialModuleProfileId = await this.resolveSubjectProfileId({
+      subjectId: props.subjectId,
+      requestedSocialModuleProfileId: props.requestedSocialModuleProfileId,
+      autoBootstrapProfile: props.autoBootstrapProfile,
+    });
+
+    const socialModuleChat = await socialModuleChatApi.create({
+      data: props.data,
+      options: {
+        headers: {
+          "X-RBAC-SECRET-KEY": RBAC_SECRET_KEY,
+        },
+      },
+    });
+
+    await socialModuleProfilesToChatsApi.create({
+      data: {
+        profileId: socialModuleProfileId,
+        chatId: socialModuleChat.id,
+      },
+      options: {
+        headers: {
+          "X-RBAC-SECRET-KEY": RBAC_SECRET_KEY,
+        },
+      },
+    });
+
+    const socialModuleDefaultThread = await this.ensureDefaultThreadForChat({
+      socialModuleChatId: socialModuleChat.id,
+    });
+
+    return {
+      socialModuleChat,
+      socialModuleProfileId,
+      socialModuleDefaultThread,
+    };
+  }
+
+  async assertSubjectOwnsChat(props: {
+    subjectId: string;
+    socialModuleChatId: string;
+  }) {
+    if (await this.isSubjectAdmin(props.subjectId)) {
+      return;
+    }
+
+    const socialModuleProfileIds = await this.getSubjectLinkedProfileIds({
+      subjectId: props.subjectId,
+      requireAny: true,
+    });
+
+    const socialModuleProfilesToChats =
+      await this.service.socialModule.profilesToChats.find({
+        params: {
+          filters: {
+            and: [
+              {
+                column: "profileId",
+                method: "inArray",
+                value: socialModuleProfileIds,
+              },
+              {
+                column: "chatId",
+                method: "eq",
+                value: props.socialModuleChatId,
+              },
+            ],
+          },
+        },
+      });
+
+    if (!socialModuleProfilesToChats?.length) {
+      throw new Error(
+        "Authorization error. Requested social-module chat does not belong to subject",
+      );
+    }
+  }
+
+  async resolveSubjectProfileIdInChat(props: {
+    subjectId: string;
+    socialModuleChatId: string;
+  }): Promise<string> {
+    const socialModuleProfileIds = await this.getSubjectLinkedProfileIds({
+      subjectId: props.subjectId,
+      requireAny: true,
+    });
+
+    const socialModuleProfilesToChats =
+      await this.service.socialModule.profilesToChats.find({
+        params: {
+          filters: {
+            and: [
+              {
+                column: "profileId",
+                method: "inArray",
+                value: socialModuleProfileIds,
+              },
+              {
+                column: "chatId",
+                method: "eq",
+                value: props.socialModuleChatId,
+              },
+            ],
+          },
+        },
+      });
+
+    if (!socialModuleProfilesToChats?.length) {
+      if (await this.isSubjectAdmin(props.subjectId)) {
+        const fallbackSocialModuleProfileId = socialModuleProfileIds[0];
+
+        if (!fallbackSocialModuleProfileId) {
+          throw new Error(
+            "Not found error. Requested subject has no social-module profile",
+          );
+        }
+
+        return fallbackSocialModuleProfileId;
+      }
+
+      throw new Error(
+        "Authorization error. Requested social-module chat does not belong to subject",
+      );
+    }
+
+    if (socialModuleProfilesToChats.length > 1) {
+      throw new Error(
+        "Validation error. Subject has multiple profiles in the requested chat",
+      );
+    }
+
+    const socialModuleProfileId = socialModuleProfilesToChats[0]?.profileId;
+
+    if (!socialModuleProfileId) {
+      throw new Error(
+        "Validation error. Requested chat relation has no socialModuleProfileId",
+      );
+    }
+
+    return socialModuleProfileId;
+  }
+
+  async assertThreadBelongsToChat(props: {
+    socialModuleChatId: string;
+    socialModuleThreadId: string;
+  }) {
+    const socialModuleChatsToThreads =
+      await this.service.socialModule.chatsToThreads.find({
+        params: {
+          filters: {
+            and: [
+              {
+                column: "chatId",
+                method: "eq",
+                value: props.socialModuleChatId,
+              },
+              {
+                column: "threadId",
+                method: "eq",
+                value: props.socialModuleThreadId,
+              },
+            ],
+          },
+        },
+      });
+
+    if (!socialModuleChatsToThreads?.length) {
+      throw new Error(
+        "Validation error. Requested thread is not linked to the requested chat",
+      );
+    }
+  }
+
+  async ensureDefaultThreadForChat(props: {
+    socialModuleChatId: string;
+  }): Promise<ISocialModuleThread> {
+    if (!RBAC_SECRET_KEY) {
+      throw new Error("Configuration error. RBAC_SECRET_KEY not set");
+    }
+
+    const secretKey = RBAC_SECRET_KEY;
+    const socialModuleChat = await this.service.socialModule.chat.findById({
+      id: props.socialModuleChatId,
+    });
+
+    if (!socialModuleChat?.id) {
+      throw new Error(
+        "Validation error. Requested social-module chat does not exist",
+      );
+    }
+
+    const socialModuleChatsToThreads =
+      await this.service.socialModule.chatsToThreads.find({
+        params: {
+          filters: {
+            and: [
+              {
+                column: "chatId",
+                method: "eq",
+                value: props.socialModuleChatId,
+              },
+            ],
+          },
+        },
+      });
+
+    const linkedThreadIds =
+      socialModuleChatsToThreads
+        ?.map((socialModuleChatToThread) => {
+          return socialModuleChatToThread.threadId;
+        })
+        .filter((threadId): threadId is string => Boolean(threadId)) || [];
+
+    if (linkedThreadIds.length) {
+      const socialModuleThreads = await this.service.socialModule.thread.find({
+        params: {
+          filters: {
+            and: [
+              {
+                column: "id",
+                method: "inArray",
+                value: linkedThreadIds,
+              },
+            ],
+          },
+        },
+      });
+
+      const defaultSocialModuleThreads =
+        socialModuleThreads?.filter((socialModuleThread) => {
+          return socialModuleThread.variant === "default";
+        }) || [];
+
+      if (defaultSocialModuleThreads.length > 1) {
+        throw new Error(
+          "Validation error. Requested social-module chat has multiple default threads",
+        );
+      }
+
+      if (defaultSocialModuleThreads.length === 1) {
+        return defaultSocialModuleThreads[0];
+      }
+    }
+
+    const socialModuleDefaultThread = await socialModuleThreadApi.create({
+      data: {
+        variant: "default",
+      },
+      options: {
+        headers: {
+          "X-RBAC-SECRET-KEY": secretKey,
+        },
+      },
+    });
+
+    if (!socialModuleDefaultThread?.id) {
+      throw new Error(
+        "Internal server error. Failed to create default thread for chat",
+      );
+    }
+
+    const persistedDefaultThread = await socialModuleThreadApi.findById({
+      id: socialModuleDefaultThread.id,
+      options: {
+        headers: {
+          "X-RBAC-SECRET-KEY": secretKey,
+        },
+      },
+    });
+
+    if (!persistedDefaultThread?.id) {
+      throw new Error(
+        "Internal server error. Created default thread was not found",
+      );
+    }
+
+    try {
+      await socialModuleChatsToThreadsApi.create({
+        data: {
+          chatId: props.socialModuleChatId,
+          threadId: persistedDefaultThread.id,
+          variant: "default",
+        },
+        options: {
+          headers: {
+            "X-RBAC-SECRET-KEY": secretKey,
+          },
+        },
+      });
+    } catch {
+      throw new Error(
+        `Internal server error. Failed to link default thread to chat. chatId=${props.socialModuleChatId}; threadId=${persistedDefaultThread.id}`,
+      );
+    }
+
+    return persistedDefaultThread;
+  }
+
+  private async resolveSubjectProfileId(props: {
+    subjectId: string;
+    requestedSocialModuleProfileId?: string;
+    autoBootstrapProfile: boolean;
+  }): Promise<string> {
+    if (!RBAC_SECRET_KEY) {
+      throw new Error("Configuration error. RBAC_SECRET_KEY not set");
+    }
+
+    const secretKey = RBAC_SECRET_KEY;
+    const linkedProfileIds = await this.getSubjectLinkedProfileIds({
+      subjectId: props.subjectId,
+    });
+
+    if (props.requestedSocialModuleProfileId) {
+      const requestedSocialModuleProfile =
+        await this.service.socialModule.profile.findById({
+          id: props.requestedSocialModuleProfileId,
+        });
+
+      if (!requestedSocialModuleProfile?.id) {
+        throw new Error(
+          "Not found error. Requested social-module profile not found",
+        );
+      }
+
+      const hasSubjectProfileRelation = linkedProfileIds.includes(
+        props.requestedSocialModuleProfileId,
+      );
+
+      if (hasSubjectProfileRelation) {
+        return props.requestedSocialModuleProfileId;
+      }
+
+      if (!props.autoBootstrapProfile) {
+        throw new Error(
+          "Authorization error. Requested social-module profile does not belong to subject",
+        );
+      }
+
+      await subjectsToSocialModuleProfilesApi.create({
+        data: {
+          subjectId: props.subjectId,
+          socialModuleProfileId: props.requestedSocialModuleProfileId,
+        },
+        options: {
+          headers: {
+            "X-RBAC-SECRET-KEY": secretKey,
+          },
+        },
+      });
+
+      return props.requestedSocialModuleProfileId;
+    }
+
+    if (linkedProfileIds.length) {
+      const socialModuleProfiles = await this.service.socialModule.profile.find(
+        {
+          params: {
+            filters: {
+              and: [
+                {
+                  column: "id",
+                  method: "inArray",
+                  value: linkedProfileIds,
+                },
+              ],
+            },
+          },
+        },
+      );
+
+      const existingProfileIds = new Set(
+        socialModuleProfiles
+          ?.map((socialModuleProfile) => {
+            return socialModuleProfile.id;
+          })
+          .filter((profileId): profileId is string => Boolean(profileId)) || [],
+      );
+
+      const firstLinkedExistingProfileId = linkedProfileIds.find(
+        (profileId) => {
+          return existingProfileIds.has(profileId);
+        },
+      );
+
+      if (firstLinkedExistingProfileId) {
+        return firstLinkedExistingProfileId;
+      }
+    }
+
+    if (!props.autoBootstrapProfile) {
+      throw new Error(
+        `Not found error. Requested subject has no social-module profile. subjectId=${props.subjectId}`,
+      );
+    }
+
+    const socialModuleProfile = await socialModuleProfileApi.create({
+      data: {},
+      options: {
+        headers: {
+          "X-RBAC-SECRET-KEY": secretKey,
+        },
+      },
+    });
+
+    await subjectsToSocialModuleProfilesApi.create({
+      data: {
+        subjectId: props.subjectId,
+        socialModuleProfileId: socialModuleProfile.id,
+      },
+      options: {
+        headers: {
+          "X-RBAC-SECRET-KEY": secretKey,
+        },
+      },
+    });
+
+    return socialModuleProfile.id;
+  }
+
+  private async getSubjectLinkedProfileIds(props: {
+    subjectId: string;
+    requireAny?: boolean;
+  }): Promise<string[]> {
+    const subjectToProfiles =
+      await this.service.subjectsToSocialModuleProfiles.find({
+        params: {
+          filters: {
+            and: [
+              {
+                column: "subjectId",
+                method: "eq",
+                value: props.subjectId,
+              },
+            ],
+          },
+        },
+      });
+
+    if (props.requireAny && !subjectToProfiles?.length) {
+      throw new Error(
+        "Not found error. Requested subject has no social-module profile",
+      );
+    }
+
+    const linkedProfileIds =
+      subjectToProfiles
+        ?.map((subjectToProfile) => {
+          return subjectToProfile.socialModuleProfileId;
+        })
+        .filter((profileId): profileId is string => Boolean(profileId)) || [];
+
+    if (props.requireAny && !linkedProfileIds.length) {
+      throw new Error(
+        "Not found error. Requested subject has no social-module profile",
+      );
+    }
+
+    return linkedProfileIds;
+  }
+
+  private async isSubjectAdmin(subjectId: string): Promise<boolean> {
+    const subjectToRoles = await this.service.subjectsToRoles.find({
+      params: {
+        filters: {
+          and: [
+            {
+              column: "subjectId",
+              method: "eq",
+              value: subjectId,
+            },
+          ],
+        },
+      },
+    });
+
+    const roleIds =
+      subjectToRoles
+        ?.map((subjectToRole) => {
+          return subjectToRole.roleId;
+        })
+        .filter((roleId): roleId is string => Boolean(roleId)) || [];
+
+    if (!roleIds.length) {
+      return false;
+    }
+
+    const roles = await this.service.role.find({
+      params: {
+        filters: {
+          and: [
+            {
+              column: "id",
+              method: "inArray",
+              value: roleIds,
+            },
+          ],
+        },
+      },
+    });
+
+    return Boolean(
+      roles?.find((role) => {
+        return role.slug === "admin";
+      }),
+    );
+  }
+}

--- a/libs/modules/rbac/models/subject/frontend/component/src/lib/singlepage/social-module/profile/chat/create/ClientComponent.tsx
+++ b/libs/modules/rbac/models/subject/frontend/component/src/lib/singlepage/social-module/profile/chat/create/ClientComponent.tsx
@@ -12,11 +12,9 @@ import { FormField } from "@sps/ui-adapter";
 const formSchema = socialModuleChatInsertSchema;
 
 export function Component(props: IComponentPropsExtended) {
-  const socialModuleProfileFindByIdChatCreate =
-    api.socialModuleProfileFindByIdChatCreate({
-      id: props.data.id,
-      socialModuleProfileId: props.socialModuleProfile.id,
-    });
+  const socialModuleChatCreate = api.socialModuleChatCreate({
+    id: props.data.id,
+  });
 
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
@@ -27,9 +25,8 @@ export function Component(props: IComponentPropsExtended) {
   });
 
   async function onSubmit(data: z.infer<typeof formSchema>) {
-    socialModuleProfileFindByIdChatCreate.mutate({
+    socialModuleChatCreate.mutate({
       id: props.data.id,
-      socialModuleProfileId: props.socialModuleProfile.id,
       data,
     });
   }

--- a/libs/modules/rbac/models/subject/frontend/component/src/lib/singlepage/social-module/profile/chat/message/list/default/ClientComponent.tsx
+++ b/libs/modules/rbac/models/subject/frontend/component/src/lib/singlepage/social-module/profile/chat/message/list/default/ClientComponent.tsx
@@ -48,11 +48,12 @@ const messageEditFormSchema = z.object({
 });
 
 export function Component(props: IComponentPropsExtended) {
-  const socialModuleProfileFindByIdChatFindByIdMessageCreate =
-    api.socialModuleProfileFindByIdChatFindByIdMessageCreate({
+  const socialModuleProfileFindByIdChatFindByIdThreadFindByIdMessageCreate =
+    api.socialModuleProfileFindByIdChatFindByIdThreadFindByIdMessageCreate({
       id: props.data.id,
       socialModuleProfileId: props.socialModuleProfile.id,
       socialModuleChatId: props.socialModuleChat.id,
+      socialModuleThreadId: props.socialModuleThreadId,
     });
   const socialModuleProfileFindByIdChatFindByIdMessageDelete =
     api.socialModuleProfileFindByIdChatFindByIdMessageDelete({
@@ -100,10 +101,11 @@ export function Component(props: IComponentPropsExtended) {
   });
 
   async function onSubmit(data: z.infer<typeof formSchema>) {
-    socialModuleProfileFindByIdChatFindByIdMessageCreate.mutate({
+    socialModuleProfileFindByIdChatFindByIdThreadFindByIdMessageCreate.mutate({
       id: props.data.id,
       socialModuleProfileId: props.socialModuleProfile.id,
       socialModuleChatId: props.socialModuleChat.id,
+      socialModuleThreadId: props.socialModuleThreadId,
       data: {
         description: data.description,
         files: data.files,
@@ -143,10 +145,12 @@ export function Component(props: IComponentPropsExtended) {
   }
 
   useEffect(() => {
-    if (socialModuleProfileFindByIdChatFindByIdMessageCreate.isSuccess) {
+    if (
+      socialModuleProfileFindByIdChatFindByIdThreadFindByIdMessageCreate.isSuccess
+    ) {
       toast.success("Message created successfully");
     }
-  }, [socialModuleProfileFindByIdChatFindByIdMessageCreate]);
+  }, [socialModuleProfileFindByIdChatFindByIdThreadFindByIdMessageCreate]);
 
   useEffect(() => {
     if (socialModuleProfileFindByIdChatFindByIdMessageUpdate.isSuccess) {

--- a/libs/modules/rbac/models/subject/frontend/component/src/lib/singlepage/social-module/profile/chat/message/list/default/Component.tsx
+++ b/libs/modules/rbac/models/subject/frontend/component/src/lib/singlepage/social-module/profile/chat/message/list/default/Component.tsx
@@ -11,6 +11,7 @@ export function Component(props: IComponentPropsExtended) {
       className={props.className}
       socialModuleProfile={props.socialModuleProfile}
       socialModuleChat={props.socialModuleChat}
+      socialModuleThreadId={props.socialModuleThreadId}
       socialModuleMessages={props.socialModuleMessages}
       socialModuleMessagesAndActionsQuery={
         props.socialModuleMessagesAndActionsQuery

--- a/libs/modules/rbac/models/subject/frontend/component/src/lib/singlepage/social-module/profile/chat/message/list/default/client.tsx
+++ b/libs/modules/rbac/models/subject/frontend/component/src/lib/singlepage/social-module/profile/chat/message/list/default/client.tsx
@@ -11,10 +11,11 @@ export default function Component(props: IComponentProps) {
   const {
     data: socialModuleMessages,
     isLoading: socialModuleMessagesIsLoading,
-  } = api.socialModuleProfileFindByIdChatFindByIdMessageFind({
+  } = api.socialModuleProfileFindByIdChatFindByIdThreadFindByIdMessageFind({
     id: props.data.id,
     socialModuleProfileId: props.socialModuleProfile.id,
     socialModuleChatId: props.socialModuleChat.id,
+    socialModuleThreadId: props.socialModuleThreadId,
     params: {
       orderBy: {
         and: [

--- a/libs/modules/rbac/models/subject/frontend/component/src/lib/singlepage/social-module/profile/chat/message/list/default/interface.ts
+++ b/libs/modules/rbac/models/subject/frontend/component/src/lib/singlepage/social-module/profile/chat/message/list/default/interface.ts
@@ -13,17 +13,18 @@ export interface IComponentProps extends ISpsComponentBase {
   data: IModel;
   socialModuleProfile: ISocialModuleProfile;
   socialModuleChat: ISocialModuleChat;
+  socialModuleThreadId: string;
   variant: typeof variant;
   className?: string;
 }
 
 export interface IComponentPropsExtended extends IComponentProps {
-  socialModuleMessages?: IResult["ISocialModuleProfileFindByIdChatFindByIdMessageFindResult"];
+  socialModuleMessages?: IResult["ISocialModuleProfileFindByIdChatFindByIdThreadFindByIdMessageFindResult"];
   socialModuleActions?: IResult["ISocialModuleProfileFindByIdChatFindByIdActionFindResult"];
   socialModuleMessagesAndActionsQuery?: (
     | {
         type: "message";
-        data: IResult["ISocialModuleProfileFindByIdChatFindByIdMessageFindResult"][0];
+        data: IResult["ISocialModuleProfileFindByIdChatFindByIdThreadFindByIdMessageFindResult"][0];
       }
     | {
         type: "action";

--- a/libs/modules/rbac/models/subject/frontend/component/src/lib/singlepage/social-module/profile/chat/message/list/default/server.tsx
+++ b/libs/modules/rbac/models/subject/frontend/component/src/lib/singlepage/social-module/profile/chat/message/list/default/server.tsx
@@ -7,10 +7,11 @@ import { api } from "@sps/rbac/models/subject/sdk/server";
 
 export default async function Component(props: IComponentProps) {
   const socialModuleMessages =
-    await api.socialModuleProfileFindByIdChatFindByIdMessageFind({
+    await api.socialModuleProfileFindByIdChatFindByIdThreadFindByIdMessageFind({
       id: props.data.id,
       socialModuleProfileId: props.socialModuleProfile.id,
       socialModuleChatId: props.socialModuleChat.id,
+      socialModuleThreadId: props.socialModuleThreadId,
       options: {
         headers: {
           "Cache-Control": "no-store",

--- a/libs/modules/rbac/models/subject/frontend/component/src/lib/singlepage/social-module/profile/chat/overview/default/ClientComponent.tsx
+++ b/libs/modules/rbac/models/subject/frontend/component/src/lib/singlepage/social-module/profile/chat/overview/default/ClientComponent.tsx
@@ -5,8 +5,102 @@ import { cn } from "@sps/shared-frontend-client-utils";
 import { Component as SocialModuleProfileChatMessageListDefault } from "../../message/list/default";
 import { Component as SocialModuleProfilesToChats } from "@sps/social/relations/profiles-to-chats/frontend/component";
 import { Component as SocialModuleProfile } from "@sps/social/models/profile/frontend/component";
+import { api } from "@sps/rbac/models/subject/sdk/client";
+import { Button } from "@sps/shared-ui-shadcn";
+import { useEffect, useMemo } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
 
 export function Component(props: IComponentPropsExtended) {
+  const router = useRouter();
+  const socialModuleChatFindByIdThreadCreate =
+    api.socialModuleChatFindByIdThreadCreate({
+      id: props.data.id,
+      socialModuleChatId: props.socialModuleChat.id,
+    });
+  const { data: socialModuleThreads, isLoading: socialModuleThreadsIsLoading } =
+    api.socialModuleChatFindByIdThreadFind({
+      id: props.data.id,
+      socialModuleChatId: props.socialModuleChat.id,
+      params: {
+        orderBy: {
+          and: [
+            {
+              column: "createdAt",
+              method: "asc",
+            },
+          ],
+        },
+      },
+      options: {
+        headers: {
+          "Cache-Control": "no-store",
+        },
+      },
+    });
+  const activeSocialModuleThreadId = useMemo(() => {
+    if (!socialModuleThreads?.length) {
+      return;
+    }
+
+    const requestedThread = socialModuleThreads.find((socialModuleThread) => {
+      return socialModuleThread.id === props.socialModuleThreadId;
+    });
+
+    if (requestedThread?.id) {
+      return requestedThread.id;
+    }
+
+    const defaultThread = socialModuleThreads.find((socialModuleThread) => {
+      return socialModuleThread.variant === "default";
+    });
+
+    if (defaultThread?.id) {
+      return defaultThread.id;
+    }
+
+    return socialModuleThreads[0]?.id;
+  }, [props.socialModuleThreadId, socialModuleThreads]);
+
+  useEffect(() => {
+    if (!activeSocialModuleThreadId) {
+      return;
+    }
+
+    if (props.socialModuleThreadId === activeSocialModuleThreadId) {
+      return;
+    }
+
+    router.replace(
+      `/social/chats/${props.socialModuleChat.id}/threads/${activeSocialModuleThreadId}`,
+    );
+  }, [
+    activeSocialModuleThreadId,
+    props.socialModuleChat.id,
+    props.socialModuleThreadId,
+    router,
+  ]);
+
+  useEffect(() => {
+    if (!socialModuleChatFindByIdThreadCreate.isSuccess) {
+      return;
+    }
+
+    if (!socialModuleChatFindByIdThreadCreate.data?.id) {
+      return;
+    }
+
+    toast.success("Thread created successfully");
+    router.push(
+      `/social/chats/${props.socialModuleChat.id}/threads/${socialModuleChatFindByIdThreadCreate.data.id}`,
+    );
+  }, [
+    router,
+    props.socialModuleChat.id,
+    socialModuleChatFindByIdThreadCreate.data,
+    socialModuleChatFindByIdThreadCreate.isSuccess,
+  ]);
+
   return (
     <div
       data-module="rbac"
@@ -34,7 +128,7 @@ export function Component(props: IComponentPropsExtended) {
         </div>
         <div className="w-fit flex gap-2">
           <SocialModuleProfilesToChats
-            isServer={props.isServer}
+            isServer={false}
             variant="find"
             apiProps={{
               params: {
@@ -60,7 +154,7 @@ export function Component(props: IComponentPropsExtended) {
 
               return (
                 <SocialModuleProfile
-                  isServer={props.isServer}
+                  isServer={false}
                   variant="find"
                   apiProps={{
                     params: {
@@ -97,16 +191,83 @@ export function Component(props: IComponentPropsExtended) {
             }}
           </SocialModuleProfilesToChats>
         </div>
+        <div className="flex w-full max-w-3xl items-center gap-2">
+          <label
+            htmlFor={`thread-selector-${props.socialModuleChat.id}`}
+            className="text-xs text-gray-600"
+          >
+            Thread
+          </label>
+          <select
+            id={`thread-selector-${props.socialModuleChat.id}`}
+            className="h-10 flex-1 rounded-md border border-gray-300 bg-white px-3 text-sm"
+            disabled={
+              socialModuleThreadsIsLoading || !socialModuleThreads?.length
+            }
+            value={activeSocialModuleThreadId || ""}
+            onChange={(event) => {
+              const socialModuleThreadId = event.target.value;
+
+              if (!socialModuleThreadId) {
+                return;
+              }
+
+              router.push(
+                `/social/chats/${props.socialModuleChat.id}/threads/${socialModuleThreadId}`,
+              );
+            }}
+          >
+            {socialModuleThreads?.map((socialModuleThread, index) => {
+              const threadTitle =
+                socialModuleThread.variant === "default"
+                  ? "Default thread"
+                  : `Thread ${index + 1}`;
+
+              return (
+                <option
+                  key={socialModuleThread.id}
+                  value={socialModuleThread.id}
+                >
+                  {threadTitle} ({socialModuleThread.id})
+                </option>
+              );
+            })}
+          </select>
+          <Button
+            variant="outline"
+            disabled={socialModuleChatFindByIdThreadCreate.isPending}
+            onClick={() => {
+              socialModuleChatFindByIdThreadCreate.mutate({
+                id: props.data.id,
+                socialModuleChatId: props.socialModuleChat.id,
+                data: {},
+              });
+            }}
+          >
+            {socialModuleChatFindByIdThreadCreate.isPending
+              ? "Creating..."
+              : "+ Thread"}
+          </Button>
+        </div>
       </div>
       <div className="flex w-full flex-col p-4">
-        <SocialModuleProfileChatMessageListDefault
-          isServer={false}
-          data={props.data}
-          language={props.language}
-          socialModuleChat={props.socialModuleChat}
-          socialModuleProfile={props.socialModuleProfile}
-          variant="social-module-profile-chat-message-list-default"
-        />
+        {!activeSocialModuleThreadId ? (
+          <div className="rounded-lg border border-gray-200 bg-gray-50 p-4 text-sm text-gray-700">
+            {socialModuleThreadsIsLoading
+              ? "Loading threads..."
+              : "No thread found for this chat."}
+          </div>
+        ) : (
+          <SocialModuleProfileChatMessageListDefault
+            isServer={false}
+            data={props.data}
+            language={props.language}
+            socialModuleChat={props.socialModuleChat}
+            socialModuleProfile={props.socialModuleProfile}
+            socialModuleThreadId={activeSocialModuleThreadId}
+            variant="social-module-profile-chat-message-list-default"
+          />
+        )}
       </div>
     </div>
   );

--- a/libs/modules/rbac/models/subject/frontend/component/src/lib/singlepage/social-module/profile/chat/overview/default/Component.tsx
+++ b/libs/modules/rbac/models/subject/frontend/component/src/lib/singlepage/social-module/profile/chat/overview/default/Component.tsx
@@ -12,6 +12,7 @@ export function Component(props: IComponentPropsExtended) {
       socialModuleProfile={props.socialModuleProfile}
       socialModuleChat={props.socialModuleChat}
       socialModuleChatId={props.socialModuleChatId}
+      socialModuleThreadId={props.socialModuleThreadId}
     />
   );
 }

--- a/libs/modules/rbac/models/subject/frontend/component/src/lib/singlepage/social-module/profile/chat/overview/default/interface.ts
+++ b/libs/modules/rbac/models/subject/frontend/component/src/lib/singlepage/social-module/profile/chat/overview/default/interface.ts
@@ -12,6 +12,7 @@ export interface IComponentProps extends ISpsComponentBase {
   data: IModel;
   socialModuleProfile: ISocialModuleProfile;
   socialModuleChatId: ISocialModuleChat["id"];
+  socialModuleThreadId?: string;
   variant: typeof variant;
   className?: string;
 }

--- a/libs/modules/rbac/models/subject/sdk/client/src/lib/singlepage/index.ts
+++ b/libs/modules/rbac/models/subject/sdk/client/src/lib/singlepage/index.ts
@@ -165,6 +165,16 @@ import {
   type IResult as ISocialModuleProfileFindByIdChatFindByIdMessageCreateResult,
 } from "./social-module/profile/find-by-id/chat/find-by-id/message/create";
 import {
+  action as socialModuleProfileFindByIdChatFindByIdThreadFindByIdMessageFind,
+  type IProps as ISocialModuleProfileFindByIdChatFindByIdThreadFindByIdMessageFindProps,
+  type IResult as ISocialModuleProfileFindByIdChatFindByIdThreadFindByIdMessageFindResult,
+} from "./social-module/profile/find-by-id/chat/find-by-id/thread/find-by-id/message/find";
+import {
+  action as socialModuleProfileFindByIdChatFindByIdThreadFindByIdMessageCreate,
+  type IProps as ISocialModuleProfileFindByIdChatFindByIdThreadFindByIdMessageCreateProps,
+  type IResult as ISocialModuleProfileFindByIdChatFindByIdThreadFindByIdMessageCreateResult,
+} from "./social-module/profile/find-by-id/chat/find-by-id/thread/find-by-id/message/create";
+import {
   action as socialModuleProfileFindByIdChatFindByIdMessageDelete,
   type IProps as ISocialModuleProfileFindByIdChatFindByIdMessageDeleteProps,
   type IResult as ISocialModuleProfileFindByIdChatFindByIdMessageDeleteResult,
@@ -194,6 +204,21 @@ import {
   type IProps as ISocialModuleProfileFindByIdChatFindByIdActionFindProps,
   type IResult as ISocialModuleProfileFindByIdChatFindByIdActionFindResult,
 } from "./social-module/profile/find-by-id/chat/find-by-id/action/find";
+import {
+  action as socialModuleChatCreate,
+  type IProps as ISocialModuleChatCreateProps,
+  type IResult as ISocialModuleChatCreateResult,
+} from "./social-module/chat/create";
+import {
+  action as socialModuleChatFindByIdThreadFind,
+  type IProps as ISocialModuleChatFindByIdThreadFindProps,
+  type IResult as ISocialModuleChatFindByIdThreadFindResult,
+} from "./social-module/chat/find-by-id/thread/find";
+import {
+  action as socialModuleChatFindByIdThreadCreate,
+  type IProps as ISocialModuleChatFindByIdThreadCreateProps,
+  type IResult as ISocialModuleChatFindByIdThreadCreateResult,
+} from "./social-module/chat/find-by-id/thread/create";
 
 export type IProps = {
   IAuthenticationInitProps: IAuthenticationInitProps;
@@ -230,12 +255,17 @@ export type IProps = {
   ISocialModuleProfileFindByIdChatFindByIdProps: ISocialModuleProfileFindByIdChatFindByIdProps;
   ISocialModuleProfileFindByIdChatFindByIdMessageFindProps: ISocialModuleProfileFindByIdChatFindByIdMessageFindProps;
   ISocialModuleProfileFindByIdChatFindByIdMessageCreateProps: ISocialModuleProfileFindByIdChatFindByIdMessageCreateProps;
+  ISocialModuleProfileFindByIdChatFindByIdThreadFindByIdMessageFindProps: ISocialModuleProfileFindByIdChatFindByIdThreadFindByIdMessageFindProps;
+  ISocialModuleProfileFindByIdChatFindByIdThreadFindByIdMessageCreateProps: ISocialModuleProfileFindByIdChatFindByIdThreadFindByIdMessageCreateProps;
   ISocialModuleProfileFindByIdChatFindByIdMessageDeleteProps: ISocialModuleProfileFindByIdChatFindByIdMessageDeleteProps;
   ISocialModuleProfileFindByIdChatFindByIdMessageUpdateProps: ISocialModuleProfileFindByIdChatFindByIdMessageUpdateProps;
   ISocialModuleProfileFindByIdChatFindByIdMessageFindByIdReactByOpenrouterProps: ISocialModuleProfileFindByIdChatFindByIdMessageFindByIdReactByOpenrouterProps;
   ISocialModuleProfileFindByIdChatFindByIdDeleteProps: ISocialModuleProfileFindByIdChatFindByIdDeleteProps;
   ISocialModuleProfileFindByIdChatFindByIdActionCreateProps: ISocialModuleProfileFindByIdChatFindByIdActionCreateProps;
   ISocialModuleProfileFindByIdChatFindByIdActionFindProps: ISocialModuleProfileFindByIdChatFindByIdActionFindProps;
+  ISocialModuleChatCreateProps: ISocialModuleChatCreateProps;
+  ISocialModuleChatFindByIdThreadFindProps: ISocialModuleChatFindByIdThreadFindProps;
+  ISocialModuleChatFindByIdThreadCreateProps: ISocialModuleChatFindByIdThreadCreateProps;
 };
 
 export type IResult = {
@@ -273,12 +303,17 @@ export type IResult = {
   ISocialModuleProfileFindByIdChatFindByIdResult: ISocialModuleProfileFindByIdChatFindByIdResult;
   ISocialModuleProfileFindByIdChatFindByIdMessageFindResult: ISocialModuleProfileFindByIdChatFindByIdMessageFindResult;
   ISocialModuleProfileFindByIdChatFindByIdMessageCreateResult: ISocialModuleProfileFindByIdChatFindByIdMessageCreateResult;
+  ISocialModuleProfileFindByIdChatFindByIdThreadFindByIdMessageFindResult: ISocialModuleProfileFindByIdChatFindByIdThreadFindByIdMessageFindResult;
+  ISocialModuleProfileFindByIdChatFindByIdThreadFindByIdMessageCreateResult: ISocialModuleProfileFindByIdChatFindByIdThreadFindByIdMessageCreateResult;
   ISocialModuleProfileFindByIdChatFindByIdMessageDeleteResult: ISocialModuleProfileFindByIdChatFindByIdMessageDeleteResult;
   ISocialModuleProfileFindByIdChatFindByIdMessageUpdateResult: ISocialModuleProfileFindByIdChatFindByIdMessageUpdateResult;
   ISocialModuleProfileFindByIdChatFindByIdMessageFindByIdReactByOpenrouterResult: ISocialModuleProfileFindByIdChatFindByIdMessageFindByIdReactByOpenrouterResult;
   ISocialModuleProfileFindByIdChatFindByIdDeleteResult: ISocialModuleProfileFindByIdChatFindByIdDeleteResult;
   ISocialModuleProfileFindByIdChatFindByIdActionCreateResult: ISocialModuleProfileFindByIdChatFindByIdActionCreateResult;
   ISocialModuleProfileFindByIdChatFindByIdActionFindResult: ISocialModuleProfileFindByIdChatFindByIdActionFindResult;
+  ISocialModuleChatCreateResult: ISocialModuleChatCreateResult;
+  ISocialModuleChatFindByIdThreadFindResult: ISocialModuleChatFindByIdThreadFindResult;
+  ISocialModuleChatFindByIdThreadCreateResult: ISocialModuleChatFindByIdThreadCreateResult;
 };
 
 export const api = {
@@ -323,10 +358,15 @@ export const api = {
   socialModuleProfileFindByIdChatFindById,
   socialModuleProfileFindByIdChatFindByIdMessageFind,
   socialModuleProfileFindByIdChatFindByIdMessageCreate,
+  socialModuleProfileFindByIdChatFindByIdThreadFindByIdMessageFind,
+  socialModuleProfileFindByIdChatFindByIdThreadFindByIdMessageCreate,
   socialModuleProfileFindByIdChatFindByIdMessageDelete,
   socialModuleProfileFindByIdChatFindByIdMessageUpdate,
   socialModuleProfileFindByIdChatFindByIdMessageFindByIdReactByOpenrouter,
   socialModuleProfileFindByIdChatFindByIdDelete,
   socialModuleProfileFindByIdChatFindByIdActionCreate,
   socialModuleProfileFindByIdChatFindByIdActionFind,
+  socialModuleChatCreate,
+  socialModuleChatFindByIdThreadFind,
+  socialModuleChatFindByIdThreadCreate,
 };

--- a/libs/modules/rbac/models/subject/sdk/client/src/lib/singlepage/social-module/chat/create.ts
+++ b/libs/modules/rbac/models/subject/sdk/client/src/lib/singlepage/social-module/chat/create.ts
@@ -1,0 +1,67 @@
+"use client";
+
+import { route, clientHost } from "@sps/rbac/models/subject/sdk/model";
+import {
+  DefaultError,
+  useMutation,
+  UseMutationOptions,
+} from "@tanstack/react-query";
+import { toast } from "sonner";
+import { globalActionsStore } from "@sps/shared-frontend-client-store";
+import { createId } from "@paralleldrive/cuid2";
+import {
+  api,
+  type IProps as IParentProps,
+  type IResult as IParentResult,
+} from "@sps/rbac/models/subject/sdk/server";
+import { saturateHeaders } from "@sps/shared-frontend-client-utils";
+
+export type IProps = {
+  reactQueryOptions?: Partial<UseMutationOptions<any, DefaultError, any>>;
+  id: string;
+};
+
+export type IResult = IParentResult["ISocialModuleChatCreateResult"];
+
+export function action(props: IProps) {
+  return useMutation<
+    IResult,
+    DefaultError,
+    IParentProps["ISocialModuleChatCreateProps"]
+  >({
+    mutationKey: [`${route}/:id/social-module/chats`],
+    mutationFn: async (
+      mutationFunctionProps: IParentProps["ISocialModuleChatCreateProps"],
+    ) => {
+      try {
+        const result = await api.socialModuleChatCreate({
+          ...mutationFunctionProps,
+          options: {
+            ...mutationFunctionProps.options,
+            headers: saturateHeaders(mutationFunctionProps.options?.headers),
+          },
+          host: clientHost,
+        });
+
+        return result;
+      } catch (error: any) {
+        toast.error(error.message);
+
+        throw error;
+      }
+    },
+    onSuccess(data) {
+      globalActionsStore.getState().addAction({
+        type: "mutation",
+        name: `${route}/:id/social-module/chats`,
+        props: this,
+        result: data,
+        timestamp: Date.now(),
+        requestId: createId(),
+      });
+
+      return data;
+    },
+    ...props?.reactQueryOptions,
+  });
+}

--- a/libs/modules/rbac/models/subject/sdk/client/src/lib/singlepage/social-module/chat/find-by-id/thread/create.ts
+++ b/libs/modules/rbac/models/subject/sdk/client/src/lib/singlepage/social-module/chat/find-by-id/thread/create.ts
@@ -1,0 +1,71 @@
+"use client";
+
+import { route, clientHost } from "@sps/rbac/models/subject/sdk/model";
+import {
+  DefaultError,
+  useMutation,
+  UseMutationOptions,
+} from "@tanstack/react-query";
+import { toast } from "sonner";
+import { globalActionsStore } from "@sps/shared-frontend-client-store";
+import { createId } from "@paralleldrive/cuid2";
+import {
+  api,
+  type IProps as IParentProps,
+  type IResult as IParentResult,
+} from "@sps/rbac/models/subject/sdk/server";
+import { saturateHeaders } from "@sps/shared-frontend-client-utils";
+
+export type IProps = {
+  reactQueryOptions?: Partial<UseMutationOptions<any, DefaultError, any>>;
+  id: string;
+  socialModuleChatId: string;
+};
+
+export type IResult =
+  IParentResult["ISocialModuleChatFindByIdThreadCreateResult"];
+
+export function action(props: IProps) {
+  return useMutation<
+    IResult,
+    DefaultError,
+    IParentProps["ISocialModuleChatFindByIdThreadCreateProps"]
+  >({
+    mutationKey: [
+      `${route}/${props.id}/social-module/chats/${props.socialModuleChatId}/threads`,
+    ],
+    mutationFn: async (
+      mutationFunctionProps: IParentProps["ISocialModuleChatFindByIdThreadCreateProps"],
+    ) => {
+      try {
+        const result = await api.socialModuleChatFindByIdThreadCreate({
+          ...mutationFunctionProps,
+          options: {
+            ...mutationFunctionProps.options,
+            headers: saturateHeaders(mutationFunctionProps.options?.headers),
+          },
+          host: clientHost,
+        });
+
+        return result;
+      } catch (error: any) {
+        toast.error(error.message);
+
+        throw error;
+      }
+    },
+    onSuccess(data) {
+      globalActionsStore.getState().addAction({
+        type: "mutation",
+        name: `${route}/${props.id}/social-module/chats/${props.socialModuleChatId}/threads`,
+        props: this,
+        result: data,
+        timestamp: Date.now(),
+        requestId: createId(),
+      });
+
+      return data;
+    },
+    ...props?.reactQueryOptions,
+  });
+}

--- a/libs/modules/rbac/models/subject/sdk/client/src/lib/singlepage/social-module/chat/find-by-id/thread/find.ts
+++ b/libs/modules/rbac/models/subject/sdk/client/src/lib/singlepage/social-module/chat/find-by-id/thread/find.ts
@@ -1,0 +1,70 @@
+"use client";
+
+import { route, clientHost } from "@sps/rbac/models/subject/sdk/model";
+import { useQuery, UseQueryOptions } from "@tanstack/react-query";
+import { globalActionsStore } from "@sps/shared-frontend-client-store";
+import { createId } from "@paralleldrive/cuid2";
+import {
+  api,
+  type IProps as IParentProps,
+  type IResult as IParentResult,
+} from "@sps/rbac/models/subject/sdk/server";
+import { saturateHeaders } from "@sps/shared-frontend-client-utils";
+import { queryClient, subscription } from "@sps/shared-frontend-client-api";
+import { STALE_TIME } from "@sps/shared-utils";
+import { useEffect } from "react";
+
+export type IProps =
+  IParentProps["ISocialModuleChatFindByIdThreadFindProps"] & {
+    reactQueryOptions?: Partial<UseQueryOptions<any>>;
+    mute?: boolean;
+  };
+
+export type IResult =
+  IParentResult["ISocialModuleChatFindByIdThreadFindResult"];
+
+export function action(props: IProps) {
+  const queryKey = `${route}/${props.id}/social-module/chats/${props.socialModuleChatId}/threads`;
+  const topics = [
+    `social.chats.${props.socialModuleChatId}.threads`,
+    "social.threads",
+  ];
+
+  useEffect(() => {
+    const unsubscribe = subscription(queryKey, queryClient);
+    return unsubscribe;
+  }, [queryKey]);
+
+  return useQuery<IResult>({
+    queryKey: [queryKey],
+    meta: {
+      topics,
+    },
+    queryFn: async () => {
+      const result = await api.socialModuleChatFindByIdThreadFind({
+        ...props,
+        options: {
+          ...props.options,
+          headers: saturateHeaders(props.options?.headers),
+        },
+        host: clientHost,
+      });
+
+      return result;
+    },
+    select(data) {
+      globalActionsStore.getState().addAction({
+        type: "query",
+        name: `${route}/${props.id}/social-module/chats/${props.socialModuleChatId}/threads`,
+        props: this,
+        result: data,
+        timestamp: Date.now(),
+        requestId: createId(),
+      });
+
+      return data;
+    },
+    staleTime: STALE_TIME,
+    ...props.reactQueryOptions,
+  });
+}

--- a/libs/modules/rbac/models/subject/sdk/client/src/lib/singlepage/social-module/profile/find-by-id/chat/find-by-id/thread/find-by-id/message/create.ts
+++ b/libs/modules/rbac/models/subject/sdk/client/src/lib/singlepage/social-module/profile/find-by-id/chat/find-by-id/thread/find-by-id/message/create.ts
@@ -1,0 +1,78 @@
+"use client";
+
+import { route, clientHost } from "@sps/rbac/models/subject/sdk/model";
+import {
+  DefaultError,
+  useMutation,
+  UseMutationOptions,
+} from "@tanstack/react-query";
+import { toast } from "sonner";
+import { globalActionsStore } from "@sps/shared-frontend-client-store";
+import { createId } from "@paralleldrive/cuid2";
+import {
+  api,
+  type IProps as IParentProps,
+  type IResult as IParentResult,
+} from "@sps/rbac/models/subject/sdk/server";
+import { saturateHeaders } from "@sps/shared-frontend-client-utils";
+
+export type IProps = {
+  reactQueryOptions?: Partial<UseMutationOptions<any, DefaultError, any>>;
+  id: string;
+  socialModuleProfileId: string;
+  socialModuleChatId: string;
+  socialModuleThreadId: string;
+};
+
+export type IResult =
+  IParentResult["ISocialModuleProfileFindByIdChatFindByIdThreadFindByIdMessageCreateResult"];
+
+export function action(props: IProps) {
+  return useMutation<
+    IResult,
+    DefaultError,
+    IParentProps["ISocialModuleProfileFindByIdChatFindByIdThreadFindByIdMessageCreateProps"]
+  >({
+    mutationKey: [
+      `${route}/${props.id}/social-module/profiles/${props.socialModuleProfileId}/chats/${props.socialModuleChatId}/threads/${props.socialModuleThreadId}/messages`,
+    ],
+    mutationFn: async (
+      mutationFunctionProps: IParentProps["ISocialModuleProfileFindByIdChatFindByIdThreadFindByIdMessageCreateProps"],
+    ) => {
+      try {
+        const result =
+          await api.socialModuleProfileFindByIdChatFindByIdThreadFindByIdMessageCreate(
+            {
+              ...mutationFunctionProps,
+              options: {
+                ...mutationFunctionProps.options,
+                headers: saturateHeaders(
+                  mutationFunctionProps.options?.headers,
+                ),
+              },
+              host: clientHost,
+            },
+          );
+
+        return result;
+      } catch (error: any) {
+        toast.error(error.message);
+
+        throw error;
+      }
+    },
+    onSuccess(data) {
+      globalActionsStore.getState().addAction({
+        type: "mutation",
+        name: `${route}/${props.id}/social-module/profiles/${props.socialModuleProfileId}/chats/${props.socialModuleChatId}/threads/${props.socialModuleThreadId}/messages`,
+        props: this,
+        result: data,
+        timestamp: Date.now(),
+        requestId: createId(),
+      });
+
+      return data;
+    },
+    ...props?.reactQueryOptions,
+  });
+}

--- a/libs/modules/rbac/models/subject/sdk/client/src/lib/singlepage/social-module/profile/find-by-id/chat/find-by-id/thread/find-by-id/message/find.ts
+++ b/libs/modules/rbac/models/subject/sdk/client/src/lib/singlepage/social-module/profile/find-by-id/chat/find-by-id/thread/find-by-id/message/find.ts
@@ -1,0 +1,74 @@
+"use client";
+
+import { route, clientHost } from "@sps/rbac/models/subject/sdk/model";
+import { useQuery, UseQueryOptions } from "@tanstack/react-query";
+import { globalActionsStore } from "@sps/shared-frontend-client-store";
+import { createId } from "@paralleldrive/cuid2";
+import {
+  api,
+  type IProps as IParentProps,
+  type IResult as IParentResult,
+} from "@sps/rbac/models/subject/sdk/server";
+import { saturateHeaders } from "@sps/shared-frontend-client-utils";
+import { queryClient, subscription } from "@sps/shared-frontend-client-api";
+import { STALE_TIME } from "@sps/shared-utils";
+import { useEffect } from "react";
+
+export type IProps =
+  IParentProps["ISocialModuleProfileFindByIdChatFindByIdThreadFindByIdMessageFindProps"] & {
+    reactQueryOptions?: Partial<UseQueryOptions<any>>;
+    mute?: boolean;
+  };
+
+export type IResult =
+  IParentResult["ISocialModuleProfileFindByIdChatFindByIdThreadFindByIdMessageFindResult"];
+
+export function action(props: IProps) {
+  const queryKey = `${route}/${props.id}/social-module/profiles/${props.socialModuleProfileId}/chats/${props.socialModuleChatId}/threads/${props.socialModuleThreadId}/messages`;
+  const topics = [
+    `social.chats.${props.socialModuleChatId}.threads.${props.socialModuleThreadId}.messages`,
+    `social.threads.${props.socialModuleThreadId}.messages`,
+    "social.messages",
+  ];
+
+  useEffect(() => {
+    const unsubscribe = subscription(queryKey, queryClient);
+    return unsubscribe;
+  }, [queryKey]);
+
+  return useQuery<IResult>({
+    queryKey: [queryKey],
+    meta: {
+      topics,
+    },
+    queryFn: async () => {
+      const result =
+        await api.socialModuleProfileFindByIdChatFindByIdThreadFindByIdMessageFind(
+          {
+            ...props,
+            options: {
+              ...props.options,
+              headers: saturateHeaders(props.options?.headers),
+            },
+            host: clientHost,
+          },
+        );
+
+      return result;
+    },
+    select(data) {
+      globalActionsStore.getState().addAction({
+        type: "query",
+        name: `${route}/${props.id}/social-module/profiles/${props.socialModuleProfileId}/chats/${props.socialModuleChatId}/threads/${props.socialModuleThreadId}/messages`,
+        props: this,
+        result: data,
+        timestamp: Date.now(),
+        requestId: createId(),
+      });
+
+      return data;
+    },
+    staleTime: STALE_TIME,
+    ...props.reactQueryOptions,
+  });
+}

--- a/libs/modules/rbac/models/subject/sdk/model/src/lib/paths.yaml
+++ b/libs/modules/rbac/models/subject/sdk/model/src/lib/paths.yaml
@@ -121,7 +121,7 @@ paths:
                 data:
                   type: string
                   description: JSON string
-                  example: '{}'
+                  example: "{}"
               required:
                 - data
       responses:
@@ -335,7 +335,7 @@ paths:
                 data:
                   type: string
                   description: JSON string
-                  example: '{}'
+                  example: "{}"
               required:
                 - data
       responses:
@@ -370,7 +370,7 @@ paths:
                 data:
                   type: string
                   description: JSON string
-                  example: '{}'
+                  example: "{}"
               required:
                 - data
       responses:
@@ -1043,7 +1043,7 @@ paths:
                 data:
                   type: string
                   description: JSON string
-                  example: '{}'
+                  example: "{}"
               required:
                 - data
       responses:
@@ -1099,7 +1099,7 @@ paths:
                 data:
                   type: string
                   description: JSON string
-                  example: '{}'
+                  example: "{}"
               required:
                 - data
       responses:
@@ -1157,7 +1157,7 @@ paths:
                 data:
                   type: string
                   description: JSON string
-                  example: '{}'
+                  example: "{}"
               required:
                 - data
       responses:
@@ -1215,7 +1215,7 @@ paths:
                 data:
                   type: string
                   description: JSON string
-                  example: '{}'
+                  example: "{}"
               required:
                 - data
       responses:
@@ -1281,6 +1281,178 @@ paths:
               schema:
                 $ref: "../../../../../../../../../libs/modules/social/models/chat/sdk/model/src/lib/social-chat.yaml"
 
+  /rbac/subjects/{id}/social-module/chats/{socialModuleChatId}/threads:
+    get:
+      tags:
+        - "rbac-subject"
+      summary: List threads
+      description: Retrieve threads for a chat
+      parameters:
+        - $ref: "../../../../../../../../../libs/shared/backend/api/src/lib/query-builder/id.yaml"
+        - name: socialModuleChatId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: List of threads
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "../../../../../../../../../libs/modules/social/models/thread/sdk/model/src/lib/social-thread.yaml"
+    post:
+      tags:
+        - "rbac-subject"
+      summary: Create thread
+      description: Create custom thread for a chat
+      parameters:
+        - $ref: "../../../../../../../../../libs/shared/backend/api/src/lib/query-builder/id.yaml"
+        - name: socialModuleChatId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                data:
+                  type: string
+                  description: JSON string
+                  example: "{}"
+              required:
+                - data
+      responses:
+        "200":
+          description: Created thread
+          content:
+            application/json:
+              schema:
+                $ref: "../../../../../../../../../libs/modules/social/models/thread/sdk/model/src/lib/social-thread.yaml"
+
+  /rbac/subjects/{id}/social-module/chats:
+    post:
+      tags:
+        - "rbac-subject"
+      summary: Create chat
+      description: Create chat for subject with profile auto-bootstrap and default thread initialization
+      parameters:
+        - $ref: "../../../../../../../../../libs/shared/backend/api/src/lib/query-builder/id.yaml"
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                data:
+                  type: string
+                  description: JSON string
+                  example: "{}"
+              required:
+                - data
+      responses:
+        "200":
+          description: Created chat
+          content:
+            application/json:
+              schema:
+                $ref: "../../../../../../../../../libs/modules/social/models/chat/sdk/model/src/lib/social-chat.yaml"
+
+  /rbac/subjects/{id}/social-module/profiles/{socialModuleProfileId}/chats/{socialModuleChatId}/threads/{socialModuleThreadId}/messages:
+    get:
+      tags:
+        - "rbac-subject"
+      summary: List thread messages
+      description: Retrieve messages for a profile chat thread
+      parameters:
+        - $ref: "../../../../../../../../../libs/shared/backend/api/src/lib/query-builder/id.yaml"
+        - name: socialModuleProfileId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: socialModuleChatId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: socialModuleThreadId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: List of thread messages
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "../../../../../../../../../libs/modules/social/models/message/sdk/model/src/lib/social-message.yaml"
+    post:
+      tags:
+        - "rbac-subject"
+      summary: Create thread message
+      description: Create message in a profile chat thread
+      parameters:
+        - $ref: "../../../../../../../../../libs/shared/backend/api/src/lib/query-builder/id.yaml"
+        - name: socialModuleProfileId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: socialModuleChatId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: socialModuleThreadId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                data:
+                  type: string
+                  description: JSON string
+                  example: "{}"
+                files:
+                  type: array
+                  items:
+                    type: string
+                    format: binary
+              required:
+                - data
+      responses:
+        "200":
+          description: Created thread message
+          content:
+            application/json:
+              schema:
+                $ref: "../../../../../../../../../libs/modules/social/models/message/sdk/model/src/lib/social-message.yaml"
+
   /rbac/subjects/{id}/social-module/profiles/{socialModuleProfileId}/chats/{socialModuleChatId}/messages:
     get:
       tags:
@@ -1340,7 +1512,7 @@ paths:
                 data:
                   type: string
                   description: JSON string
-                  example: '{}'
+                  example: "{}"
                 files:
                   type: array
                   items:
@@ -1394,7 +1566,7 @@ paths:
                 data:
                   type: string
                   description: JSON string
-                  example: '{}'
+                  example: "{}"
               required:
                 - data
       responses:
@@ -1464,7 +1636,7 @@ paths:
                 data:
                   type: string
                   description: JSON string
-                  example: '{}'
+                  example: "{}"
               required:
                 - data
       responses:

--- a/libs/modules/rbac/models/subject/sdk/server/src/lib/singlepage/index.ts
+++ b/libs/modules/rbac/models/subject/sdk/server/src/lib/singlepage/index.ts
@@ -203,6 +203,16 @@ import {
   type IResult as ISocialModuleProfileFindByIdChatFindByIdMessageCreateResult,
 } from "./social-module/profile/find-by-id/chat/find-by-id/message/create";
 import {
+  action as socialModuleProfileFindByIdChatFindByIdThreadFindByIdMessageFind,
+  type IProps as ISocialModuleProfileFindByIdChatFindByIdThreadFindByIdMessageFindProps,
+  type IResult as ISocialModuleProfileFindByIdChatFindByIdThreadFindByIdMessageFindResult,
+} from "./social-module/profile/find-by-id/chat/find-by-id/thread/find-by-id/message/find";
+import {
+  action as socialModuleProfileFindByIdChatFindByIdThreadFindByIdMessageCreate,
+  type IProps as ISocialModuleProfileFindByIdChatFindByIdThreadFindByIdMessageCreateProps,
+  type IResult as ISocialModuleProfileFindByIdChatFindByIdThreadFindByIdMessageCreateResult,
+} from "./social-module/profile/find-by-id/chat/find-by-id/thread/find-by-id/message/create";
+import {
   action as socialModuleProfileFindByIdChatFindByIdMessageDelete,
   type IProps as ISocialModuleProfileFindByIdChatFindByIdMessageDeleteProps,
   type IResult as ISocialModuleProfileFindByIdChatFindByIdMessageDeleteResult,
@@ -232,6 +242,21 @@ import {
   type IProps as ISocialModuleProfileFindByIdChatFindByIdActionFindProps,
   type IResult as ISocialModuleProfileFindByIdChatFindByIdActionFindResult,
 } from "./social-module/profile/find-by-id/chat/find-by-id/action/find";
+import {
+  action as socialModuleChatCreate,
+  type IProps as ISocialModuleChatCreateProps,
+  type IResult as ISocialModuleChatCreateResult,
+} from "./social-module/chat/create";
+import {
+  action as socialModuleChatFindByIdThreadFind,
+  type IProps as ISocialModuleChatFindByIdThreadFindProps,
+  type IResult as ISocialModuleChatFindByIdThreadFindResult,
+} from "./social-module/chat/find-by-id/thread/find";
+import {
+  action as socialModuleChatFindByIdThreadCreate,
+  type IProps as ISocialModuleChatFindByIdThreadCreateProps,
+  type IResult as ISocialModuleChatFindByIdThreadCreateResult,
+} from "./social-module/chat/find-by-id/thread/create";
 
 export type IProps = {
   INotifyProps: INotifyProps;
@@ -277,12 +302,17 @@ export type IProps = {
   ISocialModuleProfileFindByIdChatFindByIdProps: ISocialModuleProfileFindByIdChatFindByIdProps;
   ISocialModuleProfileFindByIdChatFindByIdMessageFindProps: ISocialModuleProfileFindByIdChatFindByIdMessageFindProps;
   ISocialModuleProfileFindByIdChatFindByIdMessageCreateProps: ISocialModuleProfileFindByIdChatFindByIdMessageCreateProps;
+  ISocialModuleProfileFindByIdChatFindByIdThreadFindByIdMessageFindProps: ISocialModuleProfileFindByIdChatFindByIdThreadFindByIdMessageFindProps;
+  ISocialModuleProfileFindByIdChatFindByIdThreadFindByIdMessageCreateProps: ISocialModuleProfileFindByIdChatFindByIdThreadFindByIdMessageCreateProps;
   ISocialModuleProfileFindByIdChatFindByIdMessageDeleteProps: ISocialModuleProfileFindByIdChatFindByIdMessageDeleteProps;
   ISocialModuleProfileFindByIdChatFindByIdMessageUpdateProps: ISocialModuleProfileFindByIdChatFindByIdMessageUpdateProps;
   ISocialModuleProfileFindByIdChatFindByIdMessageFindByIdReactByOpenrouterProps: ISocialModuleProfileFindByIdChatFindByIdMessageFindByIdReactByOpenrouterProps;
   ISocialModuleProfileFindByIdChatFindByIdDeleteProps: ISocialModuleProfileFindByIdChatFindByIdDeleteProps;
   ISocialModuleProfileFindByIdChatFindByIdActionCreateProps: ISocialModuleProfileFindByIdChatFindByIdActionCreateProps;
   ISocialModuleProfileFindByIdChatFindByIdActionFindProps: ISocialModuleProfileFindByIdChatFindByIdActionFindProps;
+  ISocialModuleChatCreateProps: ISocialModuleChatCreateProps;
+  ISocialModuleChatFindByIdThreadFindProps: ISocialModuleChatFindByIdThreadFindProps;
+  ISocialModuleChatFindByIdThreadCreateProps: ISocialModuleChatFindByIdThreadCreateProps;
 };
 
 export type IResult = {
@@ -329,12 +359,17 @@ export type IResult = {
   ISocialModuleProfileFindByIdChatFindByIdResult: ISocialModuleProfileFindByIdChatFindByIdResult;
   ISocialModuleProfileFindByIdChatFindByIdMessageFindResult: ISocialModuleProfileFindByIdChatFindByIdMessageFindResult;
   ISocialModuleProfileFindByIdChatFindByIdMessageCreateResult: ISocialModuleProfileFindByIdChatFindByIdMessageCreateResult;
+  ISocialModuleProfileFindByIdChatFindByIdThreadFindByIdMessageFindResult: ISocialModuleProfileFindByIdChatFindByIdThreadFindByIdMessageFindResult;
+  ISocialModuleProfileFindByIdChatFindByIdThreadFindByIdMessageCreateResult: ISocialModuleProfileFindByIdChatFindByIdThreadFindByIdMessageCreateResult;
   ISocialModuleProfileFindByIdChatFindByIdMessageDeleteResult: ISocialModuleProfileFindByIdChatFindByIdMessageDeleteResult;
   ISocialModuleProfileFindByIdChatFindByIdMessageUpdateResult: ISocialModuleProfileFindByIdChatFindByIdMessageUpdateResult;
   ISocialModuleProfileFindByIdChatFindByIdMessageFindByIdReactByOpenrouterResult: ISocialModuleProfileFindByIdChatFindByIdMessageFindByIdReactByOpenrouterResult;
   ISocialModuleProfileFindByIdChatFindByIdDeleteResult: ISocialModuleProfileFindByIdChatFindByIdDeleteResult;
   ISocialModuleProfileFindByIdChatFindByIdActionCreateResult: ISocialModuleProfileFindByIdChatFindByIdActionCreateResult;
   ISocialModuleProfileFindByIdChatFindByIdActionFindResult: ISocialModuleProfileFindByIdChatFindByIdActionFindResult;
+  ISocialModuleChatCreateResult: ISocialModuleChatCreateResult;
+  ISocialModuleChatFindByIdThreadFindResult: ISocialModuleChatFindByIdThreadFindResult;
+  ISocialModuleChatFindByIdThreadCreateResult: ISocialModuleChatFindByIdThreadCreateResult;
 };
 
 export const api = {
@@ -388,10 +423,15 @@ export const api = {
   socialModuleProfileFindByIdChatFindById,
   socialModuleProfileFindByIdChatFindByIdMessageFind,
   socialModuleProfileFindByIdChatFindByIdMessageCreate,
+  socialModuleProfileFindByIdChatFindByIdThreadFindByIdMessageFind,
+  socialModuleProfileFindByIdChatFindByIdThreadFindByIdMessageCreate,
   socialModuleProfileFindByIdChatFindByIdMessageDelete,
   socialModuleProfileFindByIdChatFindByIdMessageUpdate,
   socialModuleProfileFindByIdChatFindByIdMessageFindByIdReactByOpenrouter,
   socialModuleProfileFindByIdChatFindByIdDelete,
   socialModuleProfileFindByIdChatFindByIdActionCreate,
   socialModuleProfileFindByIdChatFindByIdActionFind,
+  socialModuleChatCreate,
+  socialModuleChatFindByIdThreadFind,
+  socialModuleChatFindByIdThreadCreate,
 };

--- a/libs/modules/rbac/models/subject/sdk/server/src/lib/singlepage/social-module/chat/create.ts
+++ b/libs/modules/rbac/models/subject/sdk/server/src/lib/singlepage/social-module/chat/create.ts
@@ -1,0 +1,56 @@
+import { serverHost, route } from "@sps/rbac/models/subject/sdk/model";
+import {
+  NextRequestOptions,
+  prepareFormDataToSend,
+  responsePipe,
+  transformResponseItem,
+} from "@sps/shared-utils";
+import QueryString from "qs";
+import { IModel as ISocialModuleChat } from "@sps/social/models/chat/sdk/model";
+
+export interface IProps {
+  id: string;
+  host?: string;
+  tag?: string;
+  revalidate?: number;
+  params?: {
+    [key: string]: any;
+  };
+  options?: Partial<NextRequestOptions>;
+  data: Partial<ISocialModuleChat>;
+}
+
+export type IResult = ISocialModuleChat;
+
+export async function action(props: IProps): Promise<IResult> {
+  const { id, params, options, host = serverHost, data } = props;
+
+  const formData = prepareFormDataToSend({ data });
+
+  const stringifiedQuery = QueryString.stringify(params, {
+    encodeValuesOnly: true,
+  });
+
+  const requestOptions: NextRequestOptions = {
+    credentials: "include",
+    method: "POST",
+    body: formData,
+    ...options,
+    next: {
+      ...options?.next,
+    },
+  };
+
+  const res = await fetch(
+    `${host}${route}/${id}/social-module/chats?${stringifiedQuery}`,
+    requestOptions,
+  );
+
+  const json = await responsePipe<{ data: IResult }>({
+    res,
+  });
+
+  const transformedData = transformResponseItem<IResult>(json);
+
+  return transformedData;
+}

--- a/libs/modules/rbac/models/subject/sdk/server/src/lib/singlepage/social-module/chat/find-by-id/thread/create.ts
+++ b/libs/modules/rbac/models/subject/sdk/server/src/lib/singlepage/social-module/chat/find-by-id/thread/create.ts
@@ -1,0 +1,64 @@
+import { serverHost, route } from "@sps/rbac/models/subject/sdk/model";
+import {
+  NextRequestOptions,
+  prepareFormDataToSend,
+  responsePipe,
+  transformResponseItem,
+} from "@sps/shared-utils";
+import QueryString from "qs";
+import { IModel as ISocialModuleThread } from "@sps/social/models/thread/sdk/model";
+
+export interface IProps {
+  id: string;
+  socialModuleChatId: string;
+  host?: string;
+  tag?: string;
+  revalidate?: number;
+  params?: {
+    [key: string]: any;
+  };
+  options?: Partial<NextRequestOptions>;
+  data: Partial<ISocialModuleThread>;
+}
+
+export type IResult = ISocialModuleThread;
+
+export async function action(props: IProps): Promise<IResult> {
+  const {
+    id,
+    socialModuleChatId,
+    params,
+    options,
+    host = serverHost,
+    data,
+  } = props;
+
+  const formData = prepareFormDataToSend({ data });
+
+  const stringifiedQuery = QueryString.stringify(params, {
+    encodeValuesOnly: true,
+  });
+
+  const requestOptions: NextRequestOptions = {
+    credentials: "include",
+    method: "POST",
+    body: formData,
+    ...options,
+    next: {
+      ...options?.next,
+    },
+  };
+
+  const res = await fetch(
+    `${host}${route}/${id}/social-module/chats/${socialModuleChatId}/threads?${stringifiedQuery}`,
+    requestOptions,
+  );
+
+  const json = await responsePipe<{ data: IResult }>({
+    res,
+  });
+
+  const transformedData = transformResponseItem<IResult>(json);
+
+  return transformedData;
+}

--- a/libs/modules/rbac/models/subject/sdk/server/src/lib/singlepage/social-module/chat/find-by-id/thread/find.ts
+++ b/libs/modules/rbac/models/subject/sdk/server/src/lib/singlepage/social-module/chat/find-by-id/thread/find.ts
@@ -1,0 +1,52 @@
+import { serverHost, route } from "@sps/rbac/models/subject/sdk/model";
+import {
+  NextRequestOptions,
+  responsePipe,
+  transformResponseItem,
+} from "@sps/shared-utils";
+import QueryString from "qs";
+import { IModel as ISocialModuleThread } from "@sps/social/models/thread/sdk/model";
+
+export interface IProps {
+  id: string;
+  socialModuleChatId: string;
+  host?: string;
+  tag?: string;
+  revalidate?: number;
+  params?: {
+    [key: string]: any;
+  };
+  options?: Partial<NextRequestOptions>;
+}
+
+export type IResult = ISocialModuleThread[];
+
+export async function action(props: IProps): Promise<IResult> {
+  const { id, socialModuleChatId, params, options, host = serverHost } = props;
+
+  const stringifiedQuery = QueryString.stringify(params, {
+    encodeValuesOnly: true,
+  });
+
+  const requestOptions: NextRequestOptions = {
+    credentials: "include",
+    method: "GET",
+    ...options,
+    next: {
+      ...options?.next,
+    },
+  };
+
+  const res = await fetch(
+    `${host}${route}/${id}/social-module/chats/${socialModuleChatId}/threads?${stringifiedQuery}`,
+    requestOptions,
+  );
+
+  const json = await responsePipe<{ data: IResult }>({
+    res,
+  });
+
+  const transformedData = transformResponseItem<IResult>(json);
+
+  return transformedData;
+}

--- a/libs/modules/rbac/models/subject/sdk/server/src/lib/singlepage/social-module/profile/find-by-id/chat/find-by-id/thread/find-by-id/message/create.ts
+++ b/libs/modules/rbac/models/subject/sdk/server/src/lib/singlepage/social-module/profile/find-by-id/chat/find-by-id/thread/find-by-id/message/create.ts
@@ -1,0 +1,70 @@
+import { serverHost, route } from "@sps/rbac/models/subject/sdk/model";
+import {
+  NextRequestOptions,
+  prepareFormDataToSend,
+  responsePipe,
+  transformResponseItem,
+} from "@sps/shared-utils";
+import QueryString from "qs";
+import { IModel as ISocialModuleMessage } from "@sps/social/models/message/sdk/model";
+
+export interface IProps {
+  id: string;
+  socialModuleProfileId: string;
+  socialModuleChatId: string;
+  socialModuleThreadId: string;
+  host?: string;
+  tag?: string;
+  revalidate?: number;
+  params?: {
+    [key: string]: any;
+  };
+  options?: Partial<NextRequestOptions>;
+  data: Partial<ISocialModuleMessage> & {
+    files?: File[] | string[];
+  };
+}
+
+export type IResult = ISocialModuleMessage;
+
+export async function action(props: IProps): Promise<IResult> {
+  const {
+    id,
+    socialModuleProfileId,
+    socialModuleChatId,
+    socialModuleThreadId,
+    params,
+    options,
+    host = serverHost,
+    data,
+  } = props;
+
+  const formData = prepareFormDataToSend({ data });
+
+  const stringifiedQuery = QueryString.stringify(params, {
+    encodeValuesOnly: true,
+  });
+
+  const requestOptions: NextRequestOptions = {
+    credentials: "include",
+    method: "POST",
+    body: formData,
+    ...options,
+    next: {
+      ...options?.next,
+    },
+  };
+
+  const res = await fetch(
+    `${host}${route}/${id}/social-module/profiles/${socialModuleProfileId}/chats/${socialModuleChatId}/threads/${socialModuleThreadId}/messages?${stringifiedQuery}`,
+    requestOptions,
+  );
+
+  const json = await responsePipe<{ data: IResult }>({
+    res,
+  });
+
+  const transformedData = transformResponseItem<IResult>(json);
+
+  return transformedData;
+}

--- a/libs/modules/rbac/models/subject/sdk/server/src/lib/singlepage/social-module/profile/find-by-id/chat/find-by-id/thread/find-by-id/message/find.ts
+++ b/libs/modules/rbac/models/subject/sdk/server/src/lib/singlepage/social-module/profile/find-by-id/chat/find-by-id/thread/find-by-id/message/find.ts
@@ -1,0 +1,62 @@
+import { serverHost, route } from "@sps/rbac/models/subject/sdk/model";
+import {
+  NextRequestOptions,
+  responsePipe,
+  transformResponseItem,
+} from "@sps/shared-utils";
+import QueryString from "qs";
+import { IModel as ISocialModuleMessage } from "@sps/social/models/message/sdk/model";
+
+export interface IProps {
+  id: string;
+  socialModuleProfileId: string;
+  socialModuleChatId: string;
+  socialModuleThreadId: string;
+  host?: string;
+  tag?: string;
+  revalidate?: number;
+  params?: {
+    [key: string]: any;
+  };
+  options?: Partial<NextRequestOptions>;
+}
+
+export type IResult = ISocialModuleMessage[];
+
+export async function action(props: IProps): Promise<IResult> {
+  const {
+    id,
+    socialModuleProfileId,
+    socialModuleChatId,
+    socialModuleThreadId,
+    params,
+    options,
+    host = serverHost,
+  } = props;
+
+  const stringifiedQuery = QueryString.stringify(params, {
+    encodeValuesOnly: true,
+  });
+
+  const requestOptions: NextRequestOptions = {
+    credentials: "include",
+    method: "GET",
+    ...options,
+    next: {
+      ...options?.next,
+    },
+  };
+
+  const res = await fetch(
+    `${host}${route}/${id}/social-module/profiles/${socialModuleProfileId}/chats/${socialModuleChatId}/threads/${socialModuleThreadId}/messages?${stringifiedQuery}`,
+    requestOptions,
+  );
+
+  const json = await responsePipe<{ data: IResult }>({
+    res,
+  });
+
+  const transformedData = transformResponseItem<IResult>(json);
+
+  return transformedData;
+}

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "test:scenario": "bash tools/testing/test-scenario.sh",
     "test:scenario:issue": "bash tools/testing/test-scenario-issue.sh",
     "test:scenario:issue-152": "bash tools/testing/test-scenario-issue-152.sh",
+    "test:scenario:issue-154": "bash tools/testing/test-scenario-issue-154.sh",
     "test:all:scoped": "npm run test:unit:scoped && npm run test:integration:scoped && npm run test:scenario:issue-152",
     "prepare": "husky",
     "openapi:build": "nx run openapi:build",

--- a/thoughts/shared/handoffs/singlepagestartup/ISSUE-154-progress.md
+++ b/thoughts/shared/handoffs/singlepagestartup/ISSUE-154-progress.md
@@ -1,0 +1,127 @@
+---
+issue_number: 154
+issue_title: "Social chat threads: default-thread routing, thread-aware replies, thread switch/create UI, and historical backfill"
+start_date: 2026-04-10T20:56:14Z
+plan_file: thoughts/shared/plans/singlepagestartup/ISSUE-154.md
+status: in_progress
+---
+
+# Implementation Progress: ISSUE-154 - Social chat threads: default-thread routing, thread-aware replies, thread switch/create UI, and historical backfill
+
+**Started**: 2026-04-10
+**Plan**: `thoughts/shared/plans/singlepagestartup/ISSUE-154.md`
+
+## Phase Progress
+
+### Phase 1: Contract And Route Realignment
+
+- [x] Started: 2026-04-10T20:56:45Z
+- [x] Completed: 2026-04-10T21:35:00Z
+- [ ] Automated verification: FAILED (`npx nx run @sps/rbac:tsc:build`) - blocked by pre-existing workspace dependency failure in `@sps/blog:tsc:build`.
+
+**Notes**: Plan comments synced through 2026-04-10T20:22:11Z; latest review feedback is already reflected in current plan content. Implemented canonical profile-thread route/controller + SDK/OpenAPI surface (`/profiles/:profileId/chats/:chatId/threads/:threadId/messages`). Added strict RBAC secret-key guard pattern to avoid `string | undefined` header type errors.
+
+### Phase 2: Backend Thread Invariants And Message Flow
+
+- [x] Started: 2026-04-10T21:36:00Z
+- [x] Completed: 2026-04-10T21:44:00Z
+- [ ] Automated verification: FAILED (`npx nx run @sps/rbac:tsc:build --excludeTaskDependencies`) - blocked by broad pre-existing workspace/module-resolution failures not specific to phase changes.
+
+**Notes**: Subject DI/bootstrap extended with `thread`, `chatsToThreads`, `threadsToMessages`; chat create now guarantees default thread bootstrap; profile chat message create flow now resolves/creates target thread and always links `threads-to-messages`; thread ownership checks are enforced through profile-thread handlers with profile-to-chat access validation. Added explicit `RBAC_SECRET_KEY` guard in `assertThreadBelongsToChat` and documented the reusable guard pattern in ISSUE-154 thoughts research/progress artifacts.
+
+### Phase 3: OpenRouter And Agent Same-Thread Replies
+
+- [x] Started: 2026-04-10T21:44:30Z
+- [x] Completed: 2026-04-10T21:58:00Z
+- [ ] Automated verification: FAILED (`npx nx run @sps/agent:tsc:build --excludeTaskDependencies`) - blocked by broad pre-existing workspace/module-resolution failures not specific to phase changes.
+
+**Notes**: `react-by-openrouter` now resolves trigger message thread via `threads-to-messages`, backfills legacy threadless messages into chat default thread, builds LLM context from the active thread only, and sends status/final reply into same thread. Agent service OpenRouter branch now resolves thread from trigger message and propagates `threadId` into direct OpenRouter error/subscription replies.
+
+### Phase 4: Frontend Thread Selector, Creation, And Path Sync
+
+- [x] Started: 2026-04-10T22:00:00Z
+- [x] Completed: 2026-04-10T22:12:00Z
+- [ ] Automated verification: PARTIAL (`git diff --name-only -- '*.ts' '*.tsx' | xargs -r npx eslint` passed; `NX_DAEMON=false NX_ISOLATE_PLUGINS=false npx nx run @sps/rbac:tsc:build --excludeTaskDependencies` still blocked by broad pre-existing module-resolution failures).
+
+**Notes**: Host social chat overview widget now resolves both `social.chats.id` and `social.threads.id` URL segments and forwards them to RBAC subject chat overview. Subject chat overview UI now loads chat threads, supports custom thread creation, keeps selected thread in canonical route (`/social/chats/:chatId/threads/:threadId`), and redirects from legacy chat-only route to a resolved default thread. Message list read/create switched to thread-scoped subject SDK routes. Added a new host page seed for canonical thread route plus matching page-to-layout/page-to-widget relations to avoid `findByUrl` length mismatch 404 on nested thread URLs.
+
+### Phase 5: Data Normalization Via Agent/Service Routine (No Migration)
+
+- [x] Started: 2026-04-10T22:16:00Z
+- [x] Completed: 2026-04-11T11:29:04Z
+- [ ] Automated verification: PARTIAL (`NX_DAEMON=false NX_ISOLATE_PLUGINS=false npx nx run @sps/agent:jest:test`, `@sps/host:jest:test`, `@sps/rbac:jest:test` passed; `NX_DAEMON=false NX_ISOLATE_PLUGINS=false npx nx run @sps/agent:tsc:build --excludeTaskDependencies` and `@sps/rbac:tsc:build --excludeTaskDependencies` still fail with broad pre-existing TS2307/module-resolution issues outside ISSUE-154 scope).
+
+**Notes**: Added idempotent agent-side normalization routine `normalizeChatThreadsAndMessageLinks(...)` in `agent/service/singlepage/index.ts`. Routine ensures default thread per chat and backfills missing `threads-to-messages` links for threadless chat messages before resolving OpenRouter reply thread context. Added BDD behavior coverage in `agent/service/singlepage/index.spec.ts` (normalization idempotence). Added scenario suite under `apps/api/specs/scenario/singlepagestartup/issue-154` with real API/DB behavior checks for: default-thread bootstrap, thread-scoped message isolation, cross-chat thread rejection, and rerunnable thread-link backfill in reaction flow. Added runner wrapper `tools/testing/test-scenario-issue-154.sh` and npm script `test:scenario:issue-154`.
+
+## Incident Log
+
+> Read this section FIRST before starting any implementation work.
+> Parallel agents: check here for known pitfalls before debugging independently.
+
+<!-- incident-count: 4 -->
+
+### Incident 1 — Workspace tsc dependency failure blocks phase verification
+
+- **Occurrences**: 1
+- **Stage**: Phase 1 - Contract And Route Realignment
+- **Symptom**: `npx nx run @sps/rbac:tsc:build` failed before target completion because dependency task `@sps/blog:tsc:build` fails with unresolved import/type issues.
+- **Root Cause**: Pre-existing repository-wide TypeScript health issue in dependency projects, not caused by phase-1 social-thread changes.
+- **Fix**: No local phase-1 code rollback; recorded blocker and isolated verification attempts (`--excludeTaskDependencies`) to confirm failure source.
+- **Reusable Pattern**: When phase checks run through dependency graph, capture first failing dependency task and classify as external blocker before attempting phase-local refactors.
+
+### Incident 2 — Header typing failure with optional RBAC secret key
+
+- **Occurrences**: 1
+- **Stage**: Phase 1 - Contract And Route Realignment
+- **Symptom**: TypeScript error on API calls using `headers: { "X-RBAC-SECRET-KEY": RBAC_SECRET_KEY }` because value is inferred as `string | undefined`.
+- **Root Cause**: `RBAC_SECRET_KEY` is optional at type level; direct header assignment violates `HeadersInit` expectations in strict checks.
+- **Fix**: Added explicit guard (`if (!RBAC_SECRET_KEY) throw ...`) before header construction and reused the narrowed `RBAC_SECRET_KEY` string for SDK header usage.
+- **Reusable Pattern**: For env-backed auth headers, never pass optional env vars directly; always guard once and propagate a strict local string.
+
+### Incident 3 — Nested thread URL not resolved by host page lookup
+
+- **Occurrences**: 1
+- **Stage**: Phase 4 - Frontend Thread Selector, Creation, And Path Sync
+- **Symptom**: Canonical URL `/social/chats/:chatId/threads/:threadId` could 404 because host page resolution requires equal URL part count and only `/social/chats/[social.chats.id]` page existed.
+- **Root Cause**: `host/page` `findByUrl` pre-filter compares URL segment lengths before expanding dynamic masks; without a page mask that includes `threads/[social.threads.id]`, nested route cannot be matched.
+- **Fix**: Added dedicated host page seed `/social/chats/[social.chats.id]/threads/[social.threads.id]` and duplicated required `pages-to-layouts` + `pages-to-widgets` links for chat list/overview widgets.
+- **Reusable Pattern**: Whenever introducing deeper canonical routes, create a matching host page mask and required relation rows, otherwise dynamic segment extraction can fail before widget rendering.
+
+### Incident 4 — Raw fetch used where SPS SDK is required
+
+- **Occurrences**: 1
+- **Stage**: Phase 2/3 follow-up hardening
+- **Symptom**: Helper methods for default-thread bootstrap used raw `fetch` calls to `/api/social/threads` and `/api/social/chats-to-threads`.
+- **Root Cause**: Temporary workaround to force same-origin runtime routing bypassed the repository rule to use SDK for model/relation access.
+- **Fix**: Replaced raw `fetch` with `serverApiFactory` + model SDK metadata (`route/query/options`) and passed runtime `apiBaseUrl` as SDK `host`.
+- **Reusable Pattern**: For internal model/relation writes, use SDK clients only; if dynamic port/origin is required, inject it via SDK `host` instead of switching to raw HTTP calls.
+
+## Summary
+
+### Changes Made
+
+- Added canonical subject profile-thread message route/SDK contract: `GET|POST /rbac/subjects/{id}/social-module/profiles/{socialModuleProfileId}/chats/{socialModuleChatId}/threads/{socialModuleThreadId}/messages`.
+- Added backend thread invariants: default-thread bootstrap on chat create, chat-thread ownership checks, and thread-message linking.
+- Aligned OpenRouter + agent reply flow to trigger-message thread with legacy threadless backfill into default thread.
+- Added frontend thread selector/create + canonical path sync in chat overview and switched message list create/find to thread-scoped endpoints.
+- Added host seed route mask for `/social/chats/[social.chats.id]/threads/[social.threads.id]` with required relations for widget rendering.
+- Added explicit guard pattern for optional `RBAC_SECRET_KEY` before env-backed header usage and documented the pattern in ISSUE-154 thoughts research/progress artifacts.
+- Removed raw `fetch` in thread-bootstrap helpers and restored SDK-based writes with dynamic host binding to the active API origin.
+- Migrated ISSUE-154 scenario test-utils to SDK-based API access (subject/social SDK) and removed raw request helper usage.
+- Added ISSUE-154 behavior tests for normalization idempotence and scenario-level routing/thread invariants.
+- Removed temporary file-inspection regression test from `agent/backend/app/api` to keep committed tests behavior-focused.
+
+### Pull Request
+
+- [ ] PR created: —
+- [ ] PR number: —
+
+### Final Status
+
+- [x] All phases completed
+- [ ] All automated verification passed
+- [ ] Issue marked as Done
+
+---
+
+**Last updated**: 2026-04-12T11:20:00Z

--- a/thoughts/shared/plans/singlepagestartup/ISSUE-154.md
+++ b/thoughts/shared/plans/singlepagestartup/ISSUE-154.md
@@ -4,6 +4,10 @@
 
 Implement thread-scoped subject chat messaging so message create/read use the same chat-thread route, OpenRouter replies stay in the triggering thread, and historical data is normalized without DB migrations.
 
+Update (2026-04-13): thread message routing is hard-cut over to profile-scoped paths:
+`/rbac/subjects/{id}/social-module/profiles/{socialModuleProfileId}/chats/{socialModuleChatId}/threads/{socialModuleThreadId}/messages`.
+Legacy chat-thread message route/SDK methods are removed.
+
 ## Current State Analysis
 
 Subject chat message flow is currently chat-scoped: create/find handlers sit under chat routes and thread support is treated as optional context. OpenRouter reaction flow posts status/final replies through subject message create without guaranteed thread propagation. Frontend chat overview/message components are not aligned to canonical thread-in-path routing.
@@ -13,9 +17,9 @@ Subject chat message flow is currently chat-scoped: create/find handlers sit und
 After implementation:
 
 - message create/read are thread-scoped via canonical route:
-  - `POST /rbac/subjects/{subjectId}/social-module/chats/{chatId}/threads/{threadId}/messages`
-  - `GET /rbac/subjects/{subjectId}/social-module/chats/{chatId}/threads/{threadId}/messages`
-- RBAC subject SDK/server/client use full chat-thread path (`/subjects/<id>/social-module/chats/<id>/threads/<id>/...`) instead of optional `threadId` filter contracts;
+  - `POST /rbac/subjects/{subjectId}/social-module/profiles/{socialModuleProfileId}/chats/{chatId}/threads/{threadId}/messages`
+  - `GET /rbac/subjects/{subjectId}/social-module/profiles/{socialModuleProfileId}/chats/{chatId}/threads/{threadId}/messages`
+- RBAC subject SDK/server/client use full profile-thread path (`/subjects/<id>/social-module/profiles/<id>/chats/<id>/threads/<id>/...`) instead of optional `threadId` filter contracts;
 - chat creation guarantees a single default thread and valid chat-thread ownership checks;
 - OpenRouter status/final replies are always created in the same thread as the trigger message;
 - frontend thread selector/create/message components are synchronized to path-based chat/thread routing (no conflicting query-driven thread identity);
@@ -55,8 +59,8 @@ Define canonical chat-thread message routes and update subject routing + SDK/Ope
 **Changes**:
 
 - register canonical thread-scoped message routes under subject scope:
-  - `GET /:id/social-module/chats/:socialModuleChatId/threads/:socialModuleThreadId/messages`
-  - `POST /:id/social-module/chats/:socialModuleChatId/threads/:socialModuleThreadId/messages`
+  - `GET /:id/social-module/profiles/:socialModuleProfileId/chats/:socialModuleChatId/threads/:socialModuleThreadId/messages`
+  - `POST /:id/social-module/profiles/:socialModuleProfileId/chats/:socialModuleChatId/threads/:socialModuleThreadId/messages`
 - keep thread list/create under chat scope:
   - `GET /:id/social-module/chats/:socialModuleChatId/threads`
   - `POST /:id/social-module/chats/:socialModuleChatId/threads`

--- a/thoughts/shared/plans/singlepagestartup/ISSUE-154.md
+++ b/thoughts/shared/plans/singlepagestartup/ISSUE-154.md
@@ -1,0 +1,396 @@
+# Social Chat Threads Implementation Plan
+
+## Overview
+
+Implement thread-scoped subject chat messaging so message create/read use the same chat-thread route, OpenRouter replies stay in the triggering thread, and historical data is normalized without DB migrations.
+
+## Current State Analysis
+
+Subject chat message flow is currently chat-scoped: create/find handlers sit under chat routes and thread support is treated as optional context. OpenRouter reaction flow posts status/final replies through subject message create without guaranteed thread propagation. Frontend chat overview/message components are not aligned to canonical thread-in-path routing.
+
+## Desired End State
+
+After implementation:
+
+- message create/read are thread-scoped via canonical route:
+  - `POST /rbac/subjects/{subjectId}/social-module/chats/{chatId}/threads/{threadId}/messages`
+  - `GET /rbac/subjects/{subjectId}/social-module/chats/{chatId}/threads/{threadId}/messages`
+- RBAC subject SDK/server/client use full chat-thread path (`/subjects/<id>/social-module/chats/<id>/threads/<id>/...`) instead of optional `threadId` filter contracts;
+- chat creation guarantees a single default thread and valid chat-thread ownership checks;
+- OpenRouter status/final replies are always created in the same thread as the trigger message;
+- frontend thread selector/create/message components are synchronized to path-based chat/thread routing (no conflicting query-driven thread identity);
+- historical threadless chat/message data is normalized by idempotent API/service routines executed via agent flow, not via new DB migrations.
+
+### Key Discoveries
+
+- Subject routes currently expose chat/message/action endpoints without canonical thread-scoped message create/read route ([index.ts:294](/Users/rogwild/code/singlepagestartup/sps-lite/libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/index.ts:294), [index.ts:330](/Users/rogwild/code/singlepagestartup/sps-lite/libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/index.ts:330)).
+- Subject message create/find are currently chat-scoped ([message/create.ts:103](/Users/rogwild/code/singlepagestartup/sps-lite/libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/find-by-id/message/create.ts:103), [message/find.ts:47](/Users/rogwild/code/singlepagestartup/sps-lite/libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/find-by-id/message/find.ts:47)).
+- OpenRouter reaction creates status/final messages via subject message create points that currently do not enforce thread continuity ([react-by-openrouter.ts:421](/Users/rogwild/code/singlepagestartup/sps-lite/libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/find-by-id/message/react-by-openrouter.ts:421), [react-by-openrouter.ts:668](/Users/rogwild/code/singlepagestartup/sps-lite/libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/find-by-id/message/react-by-openrouter.ts:668), [react-by-openrouter.ts:916](/Users/rogwild/code/singlepagestartup/sps-lite/libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/find-by-id/message/react-by-openrouter.ts:916)).
+- Frontend chat overview/message components currently do not operate on canonical chat-thread path state ([chat overview Component.tsx:9](/Users/rogwild/code/singlepagestartup/sps-lite/libs/modules/host/relations/widgets-to-external-widgets/frontend/component/src/lib/singlepage/default/social/widget/singlepage/chat/overview/default/Component.tsx:9), [message list client.tsx:14](/Users/rogwild/code/singlepagestartup/sps-lite/libs/modules/rbac/models/subject/frontend/component/src/lib/singlepage/social-module/profile/chat/message/list/default/client.tsx:14)).
+- Subject OpenAPI currently lacks chat-thread-scoped message route contracts ([paths.yaml:1284](/Users/rogwild/code/singlepagestartup/sps-lite/libs/modules/rbac/models/subject/sdk/model/src/lib/paths.yaml:1284)).
+
+## What We're NOT Doing
+
+- No new DB migrations for this issue.
+- No schema-level constraint rollout in this phase.
+- No query-only `threadId` API contract as the primary routing mechanism.
+- No unrelated refactors in social admin/admin-v2 surfaces outside subject chat flow.
+
+## Implementation Approach
+
+Move to a route-first thread model. The canonical identity of message context is `(subjectId, chatId, threadId)` in the URL path. Backend and SDK contracts are aligned first, then OpenRouter/agent propagation is fixed, then frontend selectors are bound to the same path model. Historical data normalization is executed through idempotent service/API routines triggered from agent flows.
+
+## Phase 1: Contract And Route Realignment
+
+### Overview
+
+Define canonical chat-thread message routes and update subject routing + SDK/OpenAPI so `threadId` is path-bound instead of optional filter/query input.
+
+### Changes Required
+
+#### 1. Subject route registration for thread-scoped messaging
+
+**File**: `libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/index.ts`  
+**Why**: current route surface is chat-scoped for messages.  
+**Changes**:
+
+- register canonical thread-scoped message routes under subject scope:
+  - `GET /:id/social-module/chats/:socialModuleChatId/threads/:socialModuleThreadId/messages`
+  - `POST /:id/social-module/chats/:socialModuleChatId/threads/:socialModuleThreadId/messages`
+- keep thread list/create under chat scope:
+  - `GET /:id/social-module/chats/:socialModuleChatId/threads`
+  - `POST /:id/social-module/chats/:socialModuleChatId/threads`
+- align owner middleware and RBAC subject checks to full path identity.
+
+#### 2. Subject controller handlers for thread-scoped message create/find
+
+**Files**:
+
+- `libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/chat/find-by-id/thread/find-by-id/message/find.ts`
+- `libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/chat/find-by-id/thread/find-by-id/message/create.ts`
+
+**Why**: create/read must share one canonical chat-thread route for behavior + invalidation.
+**Changes**:
+
+- implement `find` by thread path params only;
+- implement `create` by thread path params only;
+- remove optional `threadId` filter dependency from message route contract in this flow.
+
+#### 3. OpenAPI and subject SDK path updates
+
+**Files**:
+
+- `libs/modules/rbac/models/subject/sdk/model/src/lib/paths.yaml`
+- `libs/modules/rbac/models/subject/sdk/server/src/lib/singlepage/**`
+- `libs/modules/rbac/models/subject/sdk/client/src/lib/singlepage/**`
+
+**Why**: callers must consume full path contract (`/subjects/<id>/social-module/chats/<id>/threads/<id>/...`).
+**Changes**:
+
+- add thread-scoped message create/find path entries;
+- update generated/handwritten SDK wrappers to require `socialModuleThreadId` path param;
+- remove/retire optional `threadId` query/body filter as primary mechanism for message find.
+
+### Success Criteria
+
+#### Automated Verification
+
+- [ ] `npx nx run @sps/rbac:tsc:build` passes.
+- [ ] Subject SDK build/type checks pass with required thread path params.
+- [ ] OpenAPI checks pass for updated `paths.yaml`.
+
+#### Manual Verification
+
+- [ ] API docs show thread-scoped message create/find routes.
+- [ ] Subject SDK usage requires full chat-thread path for thread message operations.
+
+---
+
+## Phase 2: Backend Thread Invariants And Message Flow
+
+### Overview
+
+Ensure runtime invariants for default thread creation, chat-thread ownership validation, and thread-scoped message linking in subject backend.
+
+### Changes Required
+
+#### 1. Subject DI extension for thread relations
+
+**Files**:
+
+- `libs/modules/rbac/models/subject/backend/app/api/src/lib/di.ts`
+- `libs/modules/rbac/models/subject/backend/app/api/src/lib/bootstrap.ts`
+
+**Why**: subject handlers need direct access to `thread`, `chatsToThreads`, `threadsToMessages` services.
+**Changes**: register and inject missing services.
+
+#### 2. Chat create default thread bootstrap
+
+**File**: `libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/create.ts`  
+**Why**: every chat must have exactly one default thread at creation.  
+**Changes**:
+
+- create default thread during chat create flow;
+- create chat-thread link with default variant;
+- enforce deterministic behavior in repeated/retried requests.
+
+#### 3. Thread-scoped message create/find handler behavior
+
+**Files**:
+
+- thread-scoped message `create.ts`
+- thread-scoped message `find.ts`
+
+**Why**: route contract requires explicit chat/thread identity.
+**Changes**:
+
+- validate `(chatId, threadId)` ownership before create/find;
+- create message and always persist `threads-to-messages` link;
+- keep existing dedup (`sourceSystemId`) and attachment behavior;
+- ensure GET returns only requested thread messages.
+
+#### 4. Thread list/create handlers under chat scope
+
+**Files**:
+
+- `.../chat/find-by-id/thread/find.ts`
+- `.../chat/find-by-id/thread/create.ts`
+
+**Why**: frontend needs thread discovery and thread creation in active chat.
+**Changes**:
+
+- return chat-owned threads;
+- create user threads with `variant="custom"`;
+- keep default thread protected from accidental duplicate creation.
+
+### Success Criteria
+
+#### Automated Verification
+
+- [ ] `npx nx run @sps/rbac:jest:test` passes for updated subject chat/thread/message handlers.
+- [ ] `npx nx run @sps/rbac:tsc:build` passes after DI and handler updates.
+
+#### Manual Verification
+
+- [ ] New chat immediately has one default thread.
+- [ ] Thread-scoped POST rejects cross-chat thread usage.
+- [ ] Thread-scoped GET returns only messages from selected thread.
+
+---
+
+## Phase 3: OpenRouter And Agent Same-Thread Replies
+
+### Overview
+
+Guarantee that OpenRouter-triggered status/final messages are created in the same thread as the triggering message.
+
+### Changes Required
+
+#### 1. Resolve trigger message thread in reaction flow
+
+**File**: `libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/find-by-id/message/react-by-openrouter.ts`  
+**Why**: current reaction flow is effectively chat-scoped for status/final emits.  
+**Changes**:
+
+- resolve trigger message thread from `threads-to-messages`;
+- pass resolved `threadId` through all intermediate status/final create calls;
+- if legacy message has no thread link, bind it to chat default thread first, then continue.
+
+#### 2. Agent service propagation of thread context
+
+**Files**:
+
+- `libs/modules/agent/models/agent/backend/app/api/src/lib/di.ts`
+- `libs/modules/agent/models/agent/backend/app/api/src/lib/bootstrap.ts`
+- `libs/modules/agent/models/agent/backend/app/api/src/lib/service/singlepage/index.ts`
+
+**Why**: agent service must preserve thread identity when building context and publishing replies.
+**Changes**:
+
+- include thread services in DI;
+- add thread context to relevant service method contracts;
+- call subject thread-scoped message create route for status/final outputs.
+
+### Success Criteria
+
+#### Automated Verification
+
+- [ ] `npx nx run @sps/agent:jest:test` passes for thread propagation scenarios.
+- [ ] `npx nx run @sps/rbac:jest:test` passes for OpenRouter reaction scenarios.
+
+#### Manual Verification
+
+- [ ] Triggering OpenRouter on a thread message creates status + final replies in that same thread.
+- [ ] Context reset behavior remains isolated to active thread context.
+
+---
+
+## Phase 4: Frontend Thread Selector, Creation, And Path Sync
+
+### Overview
+
+Align existing chat overview/message components to canonical chat-thread path routing and remove thread identity conflicts between path and query.
+
+### Changes Required
+
+#### 1. Chat overview thread selector and create action
+
+**Files**:
+
+- `libs/modules/rbac/models/subject/frontend/component/src/lib/singlepage/social-module/profile/chat/overview/default/ClientComponent.tsx`
+- `libs/modules/host/relations/widgets-to-external-widgets/frontend/component/src/lib/singlepage/default/social/widget/singlepage/chat/overview/default/Component.tsx`
+
+**Why**: UI needs explicit thread selection/creation tied to path identity.
+**Changes**:
+
+- load threads for active chat;
+- render selector + create-thread action (`variant="custom"`);
+- on selection, navigate to canonical chat-thread route segment;
+- remove conflicting thread identity handling through query-only state.
+
+#### 2. Message list/send integration with thread-scoped endpoints
+
+**Files**:
+
+- `libs/modules/rbac/models/subject/frontend/component/src/lib/singlepage/social-module/profile/chat/message/list/default/client.tsx`
+- `libs/modules/rbac/models/subject/frontend/component/src/lib/singlepage/social-module/profile/chat/message/list/default/server.tsx`
+- `libs/modules/rbac/models/subject/frontend/component/src/lib/singlepage/social-module/profile/chat/message/list/default/ClientComponent.tsx`
+
+**Why**: message fetch/create should use same thread-scoped route for consistency and invalidation.
+**Changes**:
+
+- fetch messages via `GET .../chats/:chatId/threads/:threadId/messages`;
+- create messages via `POST .../chats/:chatId/threads/:threadId/messages`;
+- unify cache keys/invalidation around `(chatId, threadId)` path identity.
+
+### Success Criteria
+
+#### Automated Verification
+
+- [ ] `npx nx run @sps/rbac:jest:test` passes for thread selector/message components.
+- [ ] `npx nx run @sps/host:jest:test` passes for host widget path sync updates.
+
+#### Manual Verification
+
+- [ ] Selecting a thread switches URL to thread path and reload keeps same thread.
+- [ ] Creating a thread updates selector and routes into new thread.
+- [ ] Sending/fetching messages works only through selected thread route.
+
+---
+
+## Phase 5: Data Normalization Via Agent/Service Routine (No Migration)
+
+### Overview
+
+Backfill existing threadless records through idempotent service/API routines invoked by agent flow, with no new database migrations.
+
+### Changes Required
+
+#### 1. Service/API normalization routines
+
+**Files**:
+
+- social/subject service modules responsible for chat/thread/message consistency
+- agent-executed maintenance entrypoint (issue-scoped utility)
+
+**Why**: historical chats/messages may miss default thread or thread-message links, but migrations are out of scope.
+**Changes**:
+
+- add idempotent routines to:
+  - ensure default thread per chat;
+  - ensure thread-message link for existing chat messages;
+  - skip already-normalized records;
+- expose routine through controlled API/service function invoked by agent execution.
+
+#### 2. Regression coverage for normalization and routing
+
+**Files**:
+
+- backend BDD specs near subject/agent chat-thread handlers;
+- scenario specs under issue-154 lane.
+
+**Why**: verify safe reruns and non-regression for thread routing.
+**Changes**:
+
+- add rerunnable normalization scenario checks;
+- add OpenRouter same-thread regression tests;
+- add frontend path-sync behavior tests.
+
+### Success Criteria
+
+#### Automated Verification
+
+- [ ] Normalization routine can run repeatedly without duplicate side effects.
+- [ ] Added backend/frontend/scenario BDD tests pass in issue-154 scope.
+
+#### Manual Verification
+
+- [ ] Legacy chats/messages appear in expected default/custom threads after routine run.
+- [ ] Re-running routine produces no duplicate links and no message loss.
+
+---
+
+## Testing Strategy
+
+### Unit Tests
+
+- Subject thread route handlers:
+  - thread-scoped message create/find;
+  - cross-chat thread rejection;
+  - thread list/create behavior.
+- Agent/OpenRouter:
+  - trigger-thread resolution;
+  - status/final message same-thread publication.
+- Frontend:
+  - thread selector + create;
+  - path synchronization;
+  - thread-scoped fetch/create integration.
+
+### Integration/Scenario Tests
+
+- End-to-end flow:
+  - create chat -> default thread exists;
+  - create custom thread -> send/fetch in selected thread;
+  - OpenRouter reply remains in trigger thread.
+- Normalization flow:
+  - run service/API backfill on threadless legacy data;
+  - rerun and assert idempotence.
+
+### Manual Testing Steps
+
+1. Create chat and verify default thread is created.
+2. Create custom thread and switch to it.
+3. Send message and verify it appears only in active thread path.
+4. Trigger OpenRouter and verify status/final replies stay in same thread.
+5. Run normalization routine twice and verify no duplicates or data loss.
+
+## Performance Considerations
+
+- Thread-scoped reads should use relation-filtered queries without chat-wide scans.
+- OpenRouter thread resolution should be one relation lookup per trigger message.
+- Normalization routine should be batched and resumable to avoid long blocking operations.
+
+## Data Sync Notes
+
+- No schema migration is introduced in this issue.
+- Normalization is handled at service/API level and must be safe for repeated agent runs.
+- Rollback path: stop routine and re-run idempotently after fixing service logic.
+
+## References
+
+- Ticket: `thoughts/shared/tickets/singlepagestartup/ISSUE-154.md`
+- Research: `thoughts/shared/research/singlepagestartup/ISSUE-154.md`
+- Subject route/controller anchors:
+  - [index.ts:294](/Users/rogwild/code/singlepagestartup/sps-lite/libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/index.ts:294)
+  - [message/create.ts:103](/Users/rogwild/code/singlepagestartup/sps-lite/libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/find-by-id/message/create.ts:103)
+  - [message/find.ts:47](/Users/rogwild/code/singlepagestartup/sps-lite/libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/find-by-id/message/find.ts:47)
+  - [chat/create.ts:68](/Users/rogwild/code/singlepagestartup/sps-lite/libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/create.ts:68)
+- OpenRouter anchors:
+  - [react-by-openrouter.ts:421](/Users/rogwild/code/singlepagestartup/sps-lite/libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/find-by-id/message/react-by-openrouter.ts:421)
+  - [react-by-openrouter.ts:668](/Users/rogwild/code/singlepagestartup/sps-lite/libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/find-by-id/message/react-by-openrouter.ts:668)
+  - [react-by-openrouter.ts:916](/Users/rogwild/code/singlepagestartup/sps-lite/libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/find-by-id/message/react-by-openrouter.ts:916)
+- Frontend anchors:
+  - [chat overview Component.tsx:9](/Users/rogwild/code/singlepagestartup/sps-lite/libs/modules/host/relations/widgets-to-external-widgets/frontend/component/src/lib/singlepage/default/social/widget/singlepage/chat/overview/default/Component.tsx:9)
+  - [message list client.tsx:14](/Users/rogwild/code/singlepagestartup/sps-lite/libs/modules/rbac/models/subject/frontend/component/src/lib/singlepage/social-module/profile/chat/message/list/default/client.tsx:14)
+
+<!-- Last synced at: 2026-04-09T23:49:45Z -->

--- a/thoughts/shared/research/singlepagestartup/ISSUE-154.md
+++ b/thoughts/shared/research/singlepagestartup/ISSUE-154.md
@@ -7,8 +7,8 @@ repository: singlepagestartup
 topic: "Social chat threads: default-thread routing, thread-aware replies, thread switch/create UI, and historical backfill"
 tags: [research, codebase, social, rbac, agent, telegram, thread]
 status: complete
-last_updated: 2026-04-09
-last_updated_by: flakecode
+last_updated: 2026-04-12
+last_updated_by: codex
 ---
 
 # Research: Social chat threads: default-thread routing, thread-aware replies, thread switch/create UI, and historical backfill
@@ -222,3 +222,95 @@ Thread entities and relations are available in social module architecture and ad
 - The issue ticket references new subject thread list/create endpoints under chat scope; these endpoint paths are not present in current subject controller or subject paths.yaml route definitions.
 - The ticket references `threadId` in subject message create/find contracts; this parameter is not present in current subject message handler parsing or subject paths.yaml parameter definitions.
 - Existing repository migration patterns include idempotent SQL and rerunnable cleanup scripts; no dedicated issue-154 backfill script was located in current code paths.
+
+## Implementation Pitfalls (2026-04-11 Addendum)
+
+### Pitfall: Optional env var type in headers (`string | undefined`)
+
+When `RBAC_SECRET_KEY` is typed as `string | undefined`, TypeScript can reject:
+
+`headers: { "X-RBAC-SECRET-KEY": RBAC_SECRET_KEY }`
+
+with:
+
+`Type '{ "X-RBAC-SECRET-KEY": string | undefined; }' is not assignable to type 'HeadersInit | undefined'.`
+
+### Recommended Fix Pattern
+
+Guard the env variable before any header construction, then use it as a strict `string`.
+
+```ts
+if (!RBAC_SECRET_KEY) {
+  throw new Error("Configuration error. RBAC_SECRET_KEY not set");
+}
+
+headers: {
+  "X-RBAC-SECRET-KEY": RBAC_SECRET_KEY,
+}
+```
+
+### Why this works
+
+- Runtime safety: fails fast if configuration is missing.
+- Type safety: after the guard, `RBAC_SECRET_KEY` is narrowed to `string`, removing `string | undefined` from header value.
+- Reuse: the same guard pattern can be used in `execute` and auxiliary methods (`assert*`, `findExisting*`, notification helpers).
+
+### Pitfall: Raw `fetch` for same-service model/relation writes
+
+For internal social model/relation writes (for example creating a default thread and creating `chats-to-threads` link), raw `fetch` bypasses SDK contracts and duplicates transport concerns.
+
+### Recommended Fix Pattern
+
+Use SDK factory with model metadata (`route/query/options`) and set `host` to the current request origin (`new URL(c.req.url).origin`) when runtime port must match the active API instance.
+
+```ts
+const socialModuleThreadApi = serverApiFactory<ISocialModuleThread>({
+  route: socialModuleThreadRoute,
+  host: props.apiBaseUrl,
+  params: socialModuleThreadQuery,
+  options: socialModuleThreadOptions,
+});
+
+await socialModuleThreadApi.create({
+  data: { variant: "default" },
+  options: { headers: { "X-RBAC-SECRET-KEY": props.secretKey } },
+});
+```
+
+### Why this works
+
+- Contract safety: keeps request shape aligned with generated SDK metadata.
+- Consistency: same API call conventions as the rest of SPS backend/controller code.
+- Port correctness: `host` can be bound to the active request origin without falling back to hardcoded env URL.
+
+## Controller Ownership Addendum (2026-04-12)
+
+### Problem Pattern
+
+Thread lifecycle responsibilities were spread across multiple controllers (`profile chat create`, `profile message create`, and `openrouter reaction`), while `chat/*` controllers had duplicated ownership checks (`assertSubjectOwnsChat`) with slightly different behavior. This made failures hard to reason about and introduced regressions during thread rollout.
+
+### Correct Ownership Boundary
+
+- Bootstrap (`subject -> social profile`) is allowed only in canonical chat creation flow.
+- Chat creation owns default-thread initialization.
+- Thread/message read-write routes must remain strict ownership checks (no implicit profile/chat bootstrap).
+
+### Canonical Chain
+
+`subject -> (auto-bootstrap profile only in create-chat) -> chat -> chat-scoped default thread`
+
+### Invariants
+
+- Every chat must have exactly one default thread (`variant="default"`).
+- Default thread selection must be chat-scoped through `chats-to-threads` by `chatId`.
+- Never use a global “first default thread”.
+- If legacy chat has no linked default thread, create and link one idempotently in shared chat lifecycle logic.
+
+### Operational Guardrails
+
+- Always fail fast when `RBAC_SECRET_KEY` is missing before building secret headers.
+- Keep thread ownership validation mandatory for thread-scoped routes (`chatId + threadId` pair).
+- Do not introduce SQL/migration side-effects in issue-154 implementation; data repair must happen via API/controller lifecycle logic.
+- Keep SDK host configuration centralized via environment (`API_SERVICE_URL` / SDK defaults); do not override host in individual controller/service SDK calls.
+- Do not pass `threadId` inside `data` to profile-scoped message SDK (`socialModuleProfileFindByIdChatFindByIdMessageCreate`): that payload follows `social-message` schema and rejects unknown fields in strict typing. Use the canonical profile-thread SDK route (`socialModuleProfileFindByIdChatFindByIdThreadFindByIdMessageCreate`) for thread-targeted writes.
+- Temporary implementation-guard tests that assert source code strings/files are allowed only during local development and must be deleted before commit. Keep only behavior tests that validate runtime behavior and contracts.

--- a/thoughts/shared/research/singlepagestartup/ISSUE-154.md
+++ b/thoughts/shared/research/singlepagestartup/ISSUE-154.md
@@ -1,0 +1,224 @@
+---
+date: 2026-04-09T01:58:27+03:00
+researcher: flakecode
+git_commit: 194db65db4d7838d0dda175a25c450d7b690e98b
+branch: issue-154
+repository: singlepagestartup
+topic: "Social chat threads: default-thread routing, thread-aware replies, thread switch/create UI, and historical backfill"
+tags: [research, codebase, social, rbac, agent, telegram, thread]
+status: complete
+last_updated: 2026-04-09
+last_updated_by: flakecode
+---
+
+# Research: Social chat threads: default-thread routing, thread-aware replies, thread switch/create UI, and historical backfill
+
+**Date**: 2026-04-09T01:58:27+03:00
+**Researcher**: flakecode
+**Git Commit**: 194db65db4d7838d0dda175a25c450d7b690e98b
+**Branch**: issue-154
+**Repository**: singlepagestartup
+
+## Research Question
+
+Document the current social chat/message/thread implementation for issue #154, including:
+
+- subject-scoped message create/find behavior;
+- thread model and relation availability;
+- chat create flow and default-thread behavior in current code paths;
+- agent/openrouter/telegram reply routing;
+- frontend thread selection/thread URL state behavior;
+- existing historical context in `thoughts/shared`.
+
+## Summary
+
+The codebase currently exposes thread entities and thread relations in the social module (`thread`, `chats-to-threads`, `threads-to-messages`) through generic social APIs and admin/admin-v2 UI surfaces. In the subject-scoped chat flow, message retrieval and message creation are currently chat-linked through `chats-to-messages`, with authorship through `profiles-to-messages`, and attachments through `messages-to-file-storage-module-files`.
+
+The current subject message and agent/openrouter execution paths are chat-scoped. OpenRouter response generation reads recent chat context from `chats-to-messages` and writes replies back through the same subject message-create endpoint for the chat. Subject-side and agent-side DI surfaces currently expose chat/message relation services but do not expose thread/chats-to-threads/threads-to-messages services.
+
+In frontend subject chat message UI, message list/create calls are scoped by `socialModuleChatId`; no `threadId` handling was found in that subtree. In the subject OpenAPI path definitions for chat messages, path/query definitions for these endpoints currently describe `id`, `socialModuleProfileId`, `socialModuleChatId`, and message body fields; no thread-specific parameter is defined there.
+
+## Detailed Findings
+
+### 1. Subject-Scoped Social Chat And Message Routes
+
+Subject controller route registration includes chat list/find, message list/create/update/delete, action list/create, and openrouter reaction under:
+`/:id/social-module/profiles/:socialModuleProfileId/chats/:socialModuleChatId/...`.
+
+- Route bindings: `libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/index.ts:281`
+- Message handlers wiring: `libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/index.ts:546`
+- Ownership middleware for these routes: `libs/modules/rbac/models/subject/backend/app/middlewares/src/lib/request-profile-subject-is-owner/index.ts:12`
+
+### 2. Message Retrieval In Subject Flow Is Chat-Linked
+
+Subject message-find handler:
+
+1. validates `id`, `socialModuleProfileId`, `socialModuleChatId`;
+2. fetches `chats-to-messages` by `chatId`;
+3. fetches message rows by collected message IDs;
+4. returns message array.
+
+- Subject handler: `libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/find-by-id/message/find.ts:14`
+- Chat-to-message relation usage: `libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/find-by-id/message/find.ts:47`
+
+A generic social chat endpoint also exposes `GET /social/chats/:id/messages` with parent relation + parsed query merge pattern.
+
+- Generic endpoint registration: `libs/modules/social/models/chat/backend/app/api/src/lib/controller/singlepage/index.ts:16`
+- Generic message-find flow: `libs/modules/social/models/chat/backend/app/api/src/lib/controller/singlepage/message/find/index.ts:29`
+
+### 3. Message Create In Subject Flow Writes Chat Link + Profile Link + Files
+
+Subject message-create handler currently:
+
+1. parses multipart `data` JSON and optional `files`;
+2. optionally deduplicates by `sourceSystemId` within chat;
+3. creates social message;
+4. creates `chats-to-messages` relation;
+5. uploads attachments and creates `messages-to-file-storage-module-files` rows;
+6. triggers `profiles-to-messages.create(...)` and `notifyOtherSubjectsInChat(...)` asynchronously.
+
+- Handler: `libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/find-by-id/message/create.ts:22`
+- Source-system dedupe path: `libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/find-by-id/message/create.ts:77`
+- Chat relation create: `libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/find-by-id/message/create.ts:114`
+- Profile relation create + notify flow: `libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/find-by-id/message/create.ts:227`
+
+### 4. Chat Create Flow In Subject Path
+
+Subject chat-create handler currently:
+
+1. validates subject/profile;
+2. parses body `data` JSON;
+3. creates social chat;
+4. creates `profiles-to-chats` relation;
+5. returns created chat payload.
+
+- Handler: `libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/create.ts:16`
+- Chat create call: `libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/create.ts:68`
+- Profiles-to-chats link create: `libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/create.ts:77`
+
+Telegram bootstrap also uses chat find/create patterns for social chat bootstrap in Telegram flow.
+
+- Telegram bootstrap flow (chat creation branch): `libs/modules/rbac/models/subject/backend/app/api/src/lib/service/singlepage/telegram/bootstrap.ts:634`
+
+### 5. Thread Model And Thread Relations Exist In Social Module
+
+Thread and thread relations are present as standalone social model/relation packages:
+
+- Thread model table/schema
+- Chats-to-threads relation table/schema
+- Threads-to-messages relation table/schema
+
+- Thread fields: `libs/modules/social/models/thread/backend/repository/database/src/lib/fields/singlepage.ts:4`
+- Chats-to-threads schema: `libs/modules/social/relations/chats-to-threads/backend/repository/database/src/lib/schema.ts:10`
+- Threads-to-messages schema: `libs/modules/social/relations/threads-to-messages/backend/repository/database/src/lib/schema.ts:10`
+- Social app route mounting for thread + relations: `libs/modules/social/backend/app/api/src/lib/apps.ts:109`
+
+### 6. Subject And Agent DI Surfaces For Social Services
+
+Current subject-side social DI interface includes profile/chat/message/action + chat/message/profile relations + file relation, but does not include thread/chats-to-threads/threads-to-messages members.
+
+- Subject DI interface: `libs/modules/rbac/models/subject/backend/app/api/src/lib/di.ts:23`
+- Subject DI binding object: `libs/modules/rbac/models/subject/backend/app/api/src/lib/bootstrap.ts:155`
+
+Current agent-side social DI interface and binding expose profile/chat/message/action + profile/chat/message relations, without thread/chats-to-threads/threads-to-messages members.
+
+- Agent DI interface: `libs/modules/agent/models/agent/backend/app/api/src/lib/di.ts:10`
+- Agent DI binding object: `libs/modules/agent/models/agent/backend/app/api/src/lib/bootstrap.ts:97`
+
+### 7. Agent/OpenRouter/Telegram Reply Flow Is Chat-Scoped
+
+Agent Telegram controller receives subject action routes and dispatches `onAction`/`onMessage`.
+For message POSTs, it resolves chat via `chats-to-messages`, resolves chat profiles via `profiles-to-chats`, and then dispatches to responder profiles.
+
+- Telegram agent controller: `libs/modules/agent/models/agent/backend/app/api/src/lib/controller/singlepage/telegram/bot.ts:16`
+- Message dispatch flow: `libs/modules/agent/models/agent/backend/app/api/src/lib/controller/singlepage/telegram/bot.ts:336`
+
+OpenRouter reply path in agent service calls subject endpoint `.../messages/:socialModuleMessageId/react-by/openrouter`.
+
+- Agent responder branching: `libs/modules/agent/models/agent/backend/app/api/src/lib/service/singlepage/index.ts:106`
+- Openrouter reply creation: `libs/modules/agent/models/agent/backend/app/api/src/lib/service/singlepage/index.ts:1244`
+- Openrouter endpoint call: `libs/modules/agent/models/agent/backend/app/api/src/lib/service/singlepage/index.ts:1414`
+
+In `react-by-openrouter` handler, conversation context is built from recent `chats-to-messages` rows for the chat; result message is posted back through subject message-create in the same chat.
+
+- Context source from chats-to-messages: `libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/find-by-id/message/react-by-openrouter.ts:420`
+- Status/reply message create calls: `libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/find-by-id/message/react-by-openrouter.ts:667`
+- Final reply create: `libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/find-by-id/message/react-by-openrouter.ts:916`
+
+### 8. Frontend Subject Chat Message UI Uses Chat Scope
+
+Subject frontend message list component loads messages and actions by `socialModuleChatId` and merges them by `createdAt` in UI state.
+Message create/update/delete mutations are also invoked with `socialModuleChatId`.
+
+- Client query wrapper: `libs/modules/rbac/models/subject/frontend/component/src/lib/singlepage/social-module/profile/chat/message/list/default/client.tsx:14`
+- Message/action rendering and create/update/delete usage: `libs/modules/rbac/models/subject/frontend/component/src/lib/singlepage/social-module/profile/chat/message/list/default/ClientComponent.tsx:51`
+- Server query wrapper: `libs/modules/rbac/models/subject/frontend/component/src/lib/singlepage/social-module/profile/chat/message/list/default/server.tsx:9`
+
+No `threadId` references were found under `libs/modules/rbac/models/subject/frontend/component/src/lib/singlepage/social-module/...` in this current state.
+
+### 9. OpenAPI/SDK Contracts In Subject Paths
+
+Subject SDK model path document currently includes:
+
+- chat list/create and chat by-id;
+- chat messages get/post;
+- chat message react route;
+- chat actions get/post.
+
+- Subject paths file chat/messages section: `libs/modules/rbac/models/subject/sdk/model/src/lib/paths.yaml:1284`
+- Subject paths file react section: `libs/modules/rbac/models/subject/sdk/model/src/lib/paths.yaml:1361`
+
+Subject client/server SDK wrappers for chat message find/create and react-by-openrouter are located under:
+
+- Client wrappers: `libs/modules/rbac/models/subject/sdk/client/src/lib/singlepage/social-module/profile/find-by-id/chat/find-by-id/message/find.ts:25`
+- Server wrappers: `libs/modules/rbac/models/subject/sdk/server/src/lib/singlepage/social-module/profile/find-by-id/chat/find-by-id/message/create.ts:29`
+- Openrouter wrapper route string: `libs/modules/rbac/models/subject/sdk/server/src/lib/singlepage/social-module/profile/find-by-id/chat/find-by-id/message/react-by-openrouter.ts:57`
+
+## Code References
+
+- `libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/index.ts:293` - subject chat message route registrations
+- `libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/find-by-id/message/find.ts:47` - message lookup through chats-to-messages
+- `libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/find-by-id/message/create.ts:103` - message create + chats-to-messages link
+- `libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/create.ts:68` - subject chat create flow
+- `libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/find-by-id/message/react-by-openrouter.ts:420` - openrouter context build from chat messages
+- `libs/modules/agent/models/agent/backend/app/api/src/lib/controller/singlepage/telegram/bot.ts:336` - agent handling of inbound chat message events
+- `libs/modules/agent/models/agent/backend/app/api/src/lib/service/singlepage/index.ts:1414` - agent call into subject openrouter reaction endpoint
+- `libs/modules/rbac/models/subject/backend/app/api/src/lib/di.ts:23` - subject social DI members
+- `libs/modules/agent/models/agent/backend/app/api/src/lib/di.ts:10` - agent social DI members
+- `libs/modules/social/models/thread/backend/repository/database/src/lib/fields/singlepage.ts:4` - thread model fields including `variant`
+- `libs/modules/social/relations/chats-to-threads/backend/repository/database/src/lib/schema.ts:10` - chats-to-threads relation schema
+- `libs/modules/social/relations/threads-to-messages/backend/repository/database/src/lib/schema.ts:10` - threads-to-messages relation schema
+- `libs/modules/rbac/models/subject/frontend/component/src/lib/singlepage/social-module/profile/chat/message/list/default/client.tsx:14` - frontend chat-scoped message query
+- `libs/modules/rbac/models/subject/sdk/model/src/lib/paths.yaml:1284` - subject OpenAPI messages endpoint definition
+
+## Architecture Documentation
+
+Current social chat runtime flow in subject/agent paths is centered on these associations:
+
+- Subject ownership of profile: `subjects-to-social-module-profiles`
+- Profile membership in chat: `profiles-to-chats`
+- Message containment in chat: `chats-to-messages`
+- Message authorship/profile relation: `profiles-to-messages`
+- Message file attachments: `messages-to-file-storage-module-files`
+
+Thread entities and relations are available in social module architecture and admin/admin-v2 social surfaces, but subject chat/message controllers and agent/openrouter runtime paths currently operate through chat-message/profile-message relations.
+
+## Historical Context (from thoughts/)
+
+- `thoughts/shared/tickets/singlepagestartup/ISSUE-154.md` is the direct issue document defining desired thread routing/backfill behavior and API/UI scope.
+- `thoughts/shared/research/singlepagestartup/ISSUE-145.md`, `thoughts/shared/plans/singlepagestartup/ISSUE-145.md`, and `thoughts/shared/handoffs/singlepagestartup/ISSUE-145-progress.md` provide earlier admin-v2 migration context for social/telegram modules.
+- `thoughts/shared/research/singlepagestartup/ISSUE-150.md` and issue-152 artifacts provide related testing/matrix context.
+- No prior `ISSUE-154` research artifact existed before this document.
+
+## Related Research
+
+- `thoughts/shared/research/singlepagestartup/ISSUE-145.md`
+- `thoughts/shared/research/singlepagestartup/ISSUE-145-admin-v2-playbook.md`
+- `thoughts/shared/research/singlepagestartup/ISSUE-150.md`
+- `thoughts/shared/research/singlepagestartup/ISSUE-152.md`
+
+## Open Questions
+
+- The issue ticket references new subject thread list/create endpoints under chat scope; these endpoint paths are not present in current subject controller or subject paths.yaml route definitions.
+- The ticket references `threadId` in subject message create/find contracts; this parameter is not present in current subject message handler parsing or subject paths.yaml parameter definitions.
+- Existing repository migration patterns include idempotent SQL and rerunnable cleanup scripts; no dedicated issue-154 backfill script was located in current code paths.

--- a/tools/testing/test-scenario-issue-154.sh
+++ b/tools/testing/test-scenario-issue-154.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+PROJECT_NAMESPACE="${SCENARIO_PROJECT_NAMESPACE:-singlepagestartup}"
+
+bash tools/testing/test-scenario-issue.sh "$PROJECT_NAMESPACE" 154

--- a/tools/testing/test-scenario-issue.sh
+++ b/tools/testing/test-scenario-issue.sh
@@ -24,6 +24,23 @@ fi
 API_PID=""
 API_STARTED_BY_SCRIPT=0
 CACHE_MIDDLEWARE_VALUE="${MIDDLEWARE_HTTP_CACHE:-true}"
+SCENARIO_API_HOST="${SCENARIO_API_HOST:-127.0.0.1}"
+PREFERRED_API_PORT="${SCENARIO_API_PORT:-4000}"
+SCENARIO_REUSE_API="${SCENARIO_REUSE_API:-1}"
+API_PORT="$PREFERRED_API_PORT"
+API_BASE_URL="http://${SCENARIO_API_HOST}:${API_PORT}"
+API_LOG_FILE="/tmp/sps-api-scenario.log"
+
+set_api_endpoint() {
+  API_PORT="$1"
+  API_BASE_URL="http://${SCENARIO_API_HOST}:${API_PORT}"
+  export API_SERVICE_PORT="$API_PORT"
+  export API_SERVICE_URL="$API_BASE_URL"
+}
+
+is_api_ready() {
+  curl --silent --output /dev/null --max-time 2 "$API_BASE_URL"
+}
 
 cleanup() {
   set +e
@@ -36,36 +53,91 @@ cleanup() {
 
 trap cleanup EXIT
 
+start_api_server() {
+  echo "[scenario] Starting API server on ${API_BASE_URL}..."
+
+  (
+    cd apps/api &&
+      API_SERVICE_PORT="$API_PORT" API_SERVICE_URL="$API_BASE_URL" MIDDLEWARE_HTTP_CACHE="$CACHE_MIDDLEWARE_VALUE" bun run dev \
+        > "$API_LOG_FILE" 2>&1
+  ) &
+
+  API_PID=$!
+  API_STARTED_BY_SCRIPT=1
+
+  echo "[scenario] Waiting for API readiness on ${API_BASE_URL}..."
+  READY=0
+  for _ in $(seq 1 60); do
+    if is_api_ready; then
+      READY=1
+      break
+    fi
+
+    if ! kill -0 "$API_PID" >/dev/null 2>&1; then
+      break
+    fi
+
+    sleep 1
+  done
+
+  if [ "$READY" -eq 1 ]; then
+    return 0
+  fi
+
+  if [ -n "$API_PID" ]; then
+    kill "$API_PID" >/dev/null 2>&1 || true
+    wait "$API_PID" 2>/dev/null || true
+  fi
+
+  API_PID=""
+  API_STARTED_BY_SCRIPT=0
+
+  return 1
+}
+
 if [ "${SCENARIO_BOOTSTRAP_INFRA:-0}" = "1" ]; then
   echo "[scenario] Bootstrapping infrastructure via ./up.sh ..."
   ./up.sh
 fi
 
-if curl --silent --output /dev/null --max-time 2 http://127.0.0.1:4000; then
-  echo "[scenario] Reusing running API on http://127.0.0.1:4000"
-else
-  echo "[scenario] Starting API server..."
-  (
-    cd apps/api &&
-      MIDDLEWARE_HTTP_CACHE="$CACHE_MIDDLEWARE_VALUE" bun run dev \
-        > /tmp/sps-api-scenario.log 2>&1
-  ) &
-  API_PID=$!
-  API_STARTED_BY_SCRIPT=1
+set_api_endpoint "$PREFERRED_API_PORT"
 
-  echo "[scenario] Waiting for API readiness..."
-  READY=0
-  for _ in $(seq 1 60); do
-    if curl --silent --output /dev/null --max-time 2 http://127.0.0.1:4000; then
-      READY=1
+if [ "$SCENARIO_REUSE_API" = "1" ] && is_api_ready; then
+  echo "[scenario] Reusing running API on ${API_BASE_URL}"
+else
+  STARTED=0
+  for CANDIDATE_PORT in "$PREFERRED_API_PORT" 4001 4002 4003 4004 4005 4010 4100; do
+    set_api_endpoint "$CANDIDATE_PORT"
+
+    if is_api_ready; then
+      if [ "$SCENARIO_REUSE_API" = "1" ]; then
+        echo "[scenario] Reusing running API on ${API_BASE_URL}"
+        STARTED=1
+        break
+      fi
+
+      echo "[scenario] Port ${API_PORT} already has a running API; trying next port for isolated scenario run..."
+      continue
+    fi
+
+    if start_api_server; then
+      STARTED=1
       break
     fi
-    sleep 1
+
+    if grep -q "EADDRINUSE" "$API_LOG_FILE"; then
+      echo "[scenario] Port ${API_PORT} is in use, trying next port..."
+      continue
+    fi
+
+    echo "[scenario] API did not become ready. Last log lines:"
+    tail -n 80 "$API_LOG_FILE" || true
+    exit 1
   done
 
-  if [ "$READY" -ne 1 ]; then
-    echo "[scenario] API did not become ready. Last log lines:"
-    tail -n 80 /tmp/sps-api-scenario.log || true
+  if [ "$STARTED" -ne 1 ]; then
+    echo "[scenario] Could not start or reuse API server on candidate ports"
+    tail -n 80 "$API_LOG_FILE" || true
     exit 1
   fi
 fi
@@ -74,7 +146,7 @@ HTTP_CACHE_STATUS="$(
   curl --silent --output /tmp/sps-api-scenario-cache-check.log \
     --write-out "%{http_code}" \
     --max-time 5 \
-    http://127.0.0.1:4000/api/http-cache/clear || true
+    "$API_BASE_URL/api/http-cache/clear" || true
 )"
 
 if [ "$HTTP_CACHE_STATUS" != "200" ]; then
@@ -94,4 +166,16 @@ else
 fi
 
 echo "[scenario] Running DB-backed scenario suite for ${PROJECT_NAMESPACE}/issue-${ISSUE_NUMBER}..."
-NX_DAEMON=false NX_ISOLATE_PLUGINS=false nx run api:jest:scenario --runInBand --testPathPattern="$ISSUE_DIR"
+SCENARIO_TEST_FILES=()
+while IFS= read -r scenario_test_file; do
+  SCENARIO_TEST_FILES+=("$scenario_test_file")
+done < <(
+  find "$ISSUE_DIR" -type f \( -name "*.scenario.spec.ts" -o -name "*.scenario.spec.tsx" \) | sort
+)
+
+if [ "${#SCENARIO_TEST_FILES[@]}" -eq 0 ]; then
+  echo "[scenario] No scenario spec files found in: $ISSUE_DIR"
+  exit 1
+fi
+
+npx jest --config apps/api/jest.scenario.config.ts --runInBand --runTestsByPath "${SCENARIO_TEST_FILES[@]}"


### PR DESCRIPTION
## Summary
- Complete issue-154 cutover to profile-scoped thread message routes for social chat flows.
- Centralize chat lifecycle invariants so each chat has exactly one `variant=default` thread (with legacy-safe backfill behavior).
- Align backend, SDK, frontend, agent/openrouter, and scenario coverage around the canonical profile-thread contract.

## What Changed
- Added/updated subject singlepage controllers to support canonical chat creation and profile-thread message routes.
- Introduced chat lifecycle service for default-thread ensure/link checks and ownership-safe thread resolution.
- Updated OpenAPI/SDK surface for new profile-thread methods and integrated callers.
- Migrated frontend chat message list/create/read to profile-thread SDK methods.
- Updated agent + openrouter reply path so status/final messages target the same resolved thread.
- Added issue-154 scenario suite and supporting scenario runner command/script.
- Added behavior test coverage for agent thread normalization routine.
- Added host page + relations data for thread overview route.
- Updated issue-154 thoughts docs (plan/research/handoff) and documented test hygiene expectations.

## Testing
- Added: `apps/api/specs/scenario/singlepagestartup/issue-154/backend-social-chat-threads.scenario.spec.ts`
- Added: `libs/modules/agent/models/agent/backend/app/api/src/lib/service/singlepage/index.spec.ts`
- Added command: `npm run test:scenario:issue-154`

## Manual Verification Checklist
- [ ] `npm run test:scenario:issue-154`
- [ ] Open `/en/social/chats/:chatId/threads/:threadId` and verify thread-scoped message isolation.
- [ ] Send a Telegram message that triggers open-router and verify reply lands in the same thread.

## Notes
- This PR assumes RBAC permission records for profile-thread message routes exist in DB and are mapped in `roles-to-permissions`:
  - `GET /api/rbac/subjects/[rbac.subjects.id]/social-module/profiles/[social.profiles.id]/chats/[social.chats.id]/threads/[social.threads.id]/messages`
  - `POST /api/rbac/subjects/[rbac.subjects.id]/social-module/profiles/[social.profiles.id]/chats/[social.chats.id]/threads/[social.threads.id]/messages`
