### PR TITLE
feat: attach OpenRouter profile skills to messages

### DIFF
--- a/libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/find-by-id/message/react-by-openrouter.spec.ts
+++ b/libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/find-by-id/message/react-by-openrouter.spec.ts
@@ -97,6 +97,10 @@ interface IOpenRouterReplyValidationHandler {
     }[];
     expectedOutputModality: "text" | "image";
     language: string;
+    profileSystemMessage?: {
+      role: "user" | "assistant" | "system";
+      content: string;
+    };
   }): {
     role: "user" | "assistant" | "system";
     content:
@@ -135,11 +139,47 @@ interface IOpenRouterKnowledgeControlsHandler {
     complexity: string;
     risk_level: string;
   };
+  buildGenerationContext(props: {
+    context: {
+      role: "user" | "assistant" | "system";
+      content: string;
+    }[];
+    expectedOutputModality: "text" | "image";
+    language: string;
+    profileSystemMessage?: {
+      role: "user" | "assistant" | "system";
+      content: string;
+    };
+  }): {
+    role: "user" | "assistant" | "system";
+    content: string | { type: "text"; text: string }[];
+  }[];
   findPromptSkillsForProfile(props: {
     socialModuleProfileId: string;
     skillIds: string[];
     skillSlugs: string[];
   }): Promise<{ id: string; slug: string; status?: string }[]>;
+  getMentionedSkillSlugs(value: string): string[];
+  attachSkillMessagePrefixToContext(props: {
+    context: {
+      role: "user" | "assistant" | "system";
+      content:
+        | string
+        | (
+            | { type: "text"; text: string }
+            | { type: "image_url"; image_url: { url: string } }
+          )[];
+    }[];
+    skillMessagePrefix: string;
+  }): {
+    role: "user" | "assistant" | "system";
+    content:
+      | string
+      | (
+          | { type: "text"; text: string }
+          | { type: "image_url"; image_url: { url: string } }
+        )[];
+  }[];
   resolveManualExpectedOutputModality(model: {
     architecture?: {
       output_modalities?: string[];
@@ -182,11 +222,27 @@ interface IOpenRouterKnowledgeControlsHandler {
     useKnowledgeSearch: boolean;
     searchDocumentIds: string[];
     sources: unknown[];
+    promptSkills: { id: string; slug: string; status?: string }[];
+    skillMessagePrefix: string;
     systemMessages: {
       role: "user" | "assistant" | "system";
       content: string;
     }[];
   }>;
+  toProfileSystemMessage(props: {
+    language: string;
+    replyProfile: {
+      id: string;
+      slug: string;
+      adminTitle?: string;
+      title?: Record<string, string>;
+      subtitle?: Record<string, string>;
+      description?: Record<string, string>;
+    };
+  }): {
+    role: "user" | "assistant" | "system";
+    content: string;
+  };
 }
 
 function createMessageId(index: number) {
@@ -648,7 +704,7 @@ describe("Given: OpenRouter thread context and reply validation", () => {
 
   /**
    * BDD Scenario
-   * Given: the user selected and mentioned skills in a Knowledge chat.
+   * Given: the user selected and invoked skills in a Knowledge chat.
    * When: OpenRouter resolves prompt skills for the replying profile.
    * Then: only linked active skills are returned and unlinked requested ids are rejected.
    */
@@ -703,6 +759,207 @@ describe("Given: OpenRouter thread context and reply validation", () => {
         skillSlugs: [],
       }),
     ).rejects.toThrow("Selected social skills are not linked");
+  });
+
+  /**
+   * BDD Scenario
+   * Given: a chat message contains slash skills and reserved slash commands.
+   * When: OpenRouter parses invoked social skills.
+   * Then: only non-reserved slash tokens are treated as skills.
+   */
+  it("When: slash tokens are parsed Then: reserved commands are excluded", () => {
+    const handler = new Handler(
+      {} as any,
+    ) as unknown as IOpenRouterKnowledgeControlsHandler;
+
+    expect(
+      handler.getMentionedSkillSlugs(
+        "@knowledge /learn Store this /brief-writer /new",
+      ),
+    ).toEqual(["brief-writer"]);
+  });
+
+  /**
+   * BDD Scenario
+   * Given: the user invokes a linked profile skill with slash syntax.
+   * When: OpenRouter resolves Knowledge context for generation.
+   * Then: the skill is exposed as a user-message prefix and not as a system message.
+   */
+  it("When: slash skills are resolved Then: they become a message prefix", async () => {
+    const handler = new Handler({
+      socialModule: {
+        profilesToSkills: {
+          find: jest.fn(async () => [
+            {
+              skillId: "skill-1",
+            },
+          ]),
+        },
+        profilesToKnowledgeModuleDocuments: {
+          find: jest.fn(async () => []),
+        },
+        skill: {
+          find: jest.fn(async () => [
+            {
+              id: "skill-1",
+              title: "Brief Writer",
+              slug: "brief-writer",
+              description: "Write a concise brief.",
+              status: "active",
+            },
+          ]),
+        },
+      },
+    } as any) as unknown as IOpenRouterKnowledgeControlsHandler;
+
+    const context = await handler.resolveOpenRouterKnowledgeContext({
+      data: {},
+      replyProfile: {
+        id: "profile-1",
+      },
+      socialModuleMessage: {
+        id: "message-1",
+        description: "/brief-writer What should we answer?",
+      },
+      sanitizedQuery: "What should we answer?",
+      requestedKnowledgeSearch: false,
+      requestedSkillIds: [],
+    });
+
+    expect(context.promptSkills).toEqual([
+      expect.objectContaining({
+        id: "skill-1",
+        slug: "brief-writer",
+      }),
+    ]);
+    expect(context.skillMessagePrefix).toContain("/brief-writer");
+    expect(context.skillMessagePrefix).toContain("Write a concise brief.");
+    expect(context.systemMessages).toEqual([]);
+  });
+
+  /**
+   * BDD Scenario
+   * Given: the OpenRouter context contains a trigger user message.
+   * When: a selected skill prefix is attached.
+   * Then: only the latest user message receives the prefix while file parts are preserved.
+   */
+  it("When: a skill prefix is attached Then: the latest user message is prefixed", () => {
+    const handler = new Handler(
+      {} as any,
+    ) as unknown as IOpenRouterKnowledgeControlsHandler;
+
+    expect(
+      handler.attachSkillMessagePrefixToContext({
+        context: [
+          {
+            role: "assistant",
+            content: "Previous answer",
+          },
+          {
+            role: "user",
+            content: "Rewrite this",
+          },
+        ],
+        skillMessagePrefix: "Selected social skills for this message:",
+      }),
+    ).toEqual([
+      {
+        role: "assistant",
+        content: "Previous answer",
+      },
+      {
+        role: "user",
+        content: "Selected social skills for this message:\n\nRewrite this",
+      },
+    ]);
+
+    expect(
+      handler.attachSkillMessagePrefixToContext({
+        context: [
+          {
+            role: "user",
+            content: [
+              {
+                type: "text",
+                text: "Use this image",
+              },
+              {
+                type: "image_url",
+                image_url: {
+                  url: "https://example.test/image.png",
+                },
+              },
+            ],
+          },
+        ],
+        skillMessagePrefix: "Skill instructions",
+      }),
+    ).toEqual([
+      {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: "Skill instructions\n\nUse this image",
+          },
+          {
+            type: "image_url",
+            image_url: {
+              url: "https://example.test/image.png",
+            },
+          },
+        ],
+      },
+    ]);
+  });
+
+  /**
+   * BDD Scenario
+   * Given: the replying profile has localized title and description.
+   * When: OpenRouter builds generation context.
+   * Then: profile persona is included as system context before conversation history.
+   */
+  it("When: generation context is built Then: profile persona is a system message", () => {
+    const handler = new Handler(
+      {} as any,
+    ) as unknown as IOpenRouterKnowledgeControlsHandler;
+    const profileSystemMessage = handler.toProfileSystemMessage({
+      language: "ru",
+      replyProfile: {
+        id: "profile-1",
+        slug: "chat-gpt-1",
+        adminTitle: "Chat GPT 1",
+        title: {
+          ru: "Редактор",
+        },
+        description: {
+          ru: "Редактирует пользовательский текст без переписывания смысла.",
+        },
+      },
+    });
+
+    const generationContext = handler.buildGenerationContext({
+      context: [
+        {
+          role: "user",
+          content: "Поправь текст",
+        },
+      ],
+      expectedOutputModality: "text",
+      language: "ru",
+      profileSystemMessage,
+    });
+
+    expect(generationContext[2]).toMatchObject({
+      role: "system",
+      content: expect.stringContaining(
+        "Редактирует пользовательский текст без переписывания смысла.",
+      ),
+    });
+    expect(generationContext[generationContext.length - 1]).toEqual({
+      role: "user",
+      content: "Поправь текст",
+    });
   });
 
   /**

--- a/libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/find-by-id/message/react-by-openrouter.ts
+++ b/libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/find-by-id/message/react-by-openrouter.ts
@@ -119,6 +119,7 @@ interface IResolvedOpenRouterKnowledgeContext {
   searchDocumentIds: string[];
   sources: KnowledgeSearchResult[];
   promptSkills: ISocialModuleSkill[];
+  skillMessagePrefix: string;
   systemMessages: IOpenRouterRequestMessage[];
 }
 
@@ -1316,10 +1317,18 @@ export class Handler {
           requestedKnowledgeSearch,
           requestedSkillIds,
         });
-      const generationContext = this.buildGenerationContext({
+      const openRouterContext = this.attachSkillMessagePrefixToContext({
         context,
+        skillMessagePrefix: openRouterKnowledgeContext.skillMessagePrefix,
+      });
+      const generationContext = this.buildGenerationContext({
+        context: openRouterContext,
         expectedOutputModality,
         language: requestClassification.language,
+        profileSystemMessage: this.toProfileSystemMessage({
+          language: requestClassification.language,
+          replyProfile: replyBySocialModuleProfile,
+        }),
         prependedSystemMessages: openRouterKnowledgeContext.systemMessages,
       });
       const openRouterReasoning = this.toOpenRouterReasoning(
@@ -1432,7 +1441,8 @@ export class Handler {
               return {
                 skillId: skill.id,
                 slug: skill.slug,
-                mode: "prompt-instruction",
+                title: skill.title,
+                mode: "message-prefix-instruction",
               };
             }),
             openRouter: {
@@ -1616,14 +1626,6 @@ export class Handler {
           })
         : [];
     const systemMessages: IOpenRouterRequestMessage[] = [
-      ...(promptSkills.length
-        ? [
-            {
-              role: "system" as const,
-              content: this.toSkillSystemPrompt(promptSkills),
-            },
-          ]
-        : []),
       ...(useKnowledgeSearch
         ? [
             {
@@ -1646,6 +1648,7 @@ export class Handler {
       searchDocumentIds,
       sources,
       promptSkills,
+      skillMessagePrefix: this.toSkillMessagePrefix(promptSkills),
       systemMessages,
     };
   }
@@ -1850,23 +1853,101 @@ export class Handler {
       });
   }
 
-  private toSkillSystemPrompt(skills: ISocialModuleSkill[]) {
+  private toSkillMessagePrefix(skills: ISocialModuleSkill[]) {
+    if (!skills.length) {
+      return "";
+    }
+
     const skillText = skills
       .map((skill) => {
         return [
-          `@${skill.slug}${skill.title ? ` (${skill.title})` : ""}`,
+          `/${skill.slug}${skill.title ? ` (${skill.title})` : ""}`,
           skill.description,
         ].join("\n");
       })
       .join("\n\n---\n\n");
 
     return [
-      "Selected social skills are active for this reply.",
+      "Selected social skills for this message:",
       "Follow these instructions for formatting, tone, and task behavior.",
       "Use the latest user message and thread context as source material when the user asks to transform or edit text.",
       "",
       skillText,
+      "",
+      "User message:",
     ].join("\n");
+  }
+
+  private attachSkillMessagePrefixToContext(props: {
+    context: IOpenRouterRequestMessage[];
+    skillMessagePrefix: string;
+  }): IOpenRouterRequestMessage[] {
+    const skillMessagePrefix = props.skillMessagePrefix.trim();
+
+    if (!skillMessagePrefix) {
+      return props.context;
+    }
+
+    const nextContext = [...props.context];
+
+    for (let index = nextContext.length - 1; index >= 0; index -= 1) {
+      const message = nextContext[index];
+
+      if (message.role !== "user") {
+        continue;
+      }
+
+      nextContext[index] = {
+        ...message,
+        content: this.prefixOpenRouterMessageContent({
+          content: message.content,
+          prefix: skillMessagePrefix,
+        }),
+      };
+
+      return nextContext;
+    }
+
+    return nextContext;
+  }
+
+  private prefixOpenRouterMessageContent(props: {
+    content: IOpenRouterRequestMessage["content"];
+    prefix: string;
+  }): IOpenRouterRequestMessage["content"] {
+    if (typeof props.content === "string") {
+      return this.joinSkillPrefixAndMessage(props.prefix, props.content);
+    }
+
+    let prefixedTextPart = false;
+    const content = props.content.map((part) => {
+      if (part.type !== "text" || prefixedTextPart) {
+        return part;
+      }
+
+      prefixedTextPart = true;
+
+      return {
+        ...part,
+        text: this.joinSkillPrefixAndMessage(props.prefix, part.text),
+      };
+    });
+
+    if (prefixedTextPart) {
+      return content;
+    }
+
+    return [
+      {
+        type: "text",
+        text: props.prefix,
+      },
+      ...content,
+    ];
+  }
+
+  private joinSkillPrefixAndMessage(prefix: string, message: string) {
+    return [prefix.trim(), message.trim()].filter(Boolean).join("\n\n");
   }
 
   private toKnowledgeSystemPrompt(props: {
@@ -2215,9 +2296,9 @@ export class Handler {
   private getMentionedSkillSlugs(value: string) {
     return Array.from(
       new Set(
-        Array.from(value.matchAll(/(^|\s)@([a-zA-Z0-9._-]+)(?=\s|$)/g))
+        Array.from(value.matchAll(/(^|\s)\/([a-zA-Z0-9._-]+)(?=\s|$)/g))
           .map((match) => match[2].toLowerCase())
-          .filter((slug) => slug !== "knowledge"),
+          .filter((slug) => !this.isReservedSlashCommandSlug(slug)),
       ),
     );
   }
@@ -2230,9 +2311,18 @@ export class Handler {
 
   private stripSkillMentions(value: string) {
     return this.toLearnText(value)
-      .replace(/(^|\s)@[a-zA-Z0-9._-]+/g, " ")
+      .replace(/(^|\s)@[a-zA-Z0-9._-]+(?=\s|$)/g, " ")
+      .replace(/(^|\s)\/([a-zA-Z0-9._-]+)(?=\s|$)/g, (_, prefix, slug) => {
+        return this.isReservedSlashCommandSlug(slug)
+          ? `${prefix}/${slug}`
+          : prefix || " ";
+      })
       .replace(/\s+/g, " ")
       .trim();
+  }
+
+  private isReservedSlashCommandSlug(value: string) {
+    return ["learn", "new"].includes(value.toLowerCase());
   }
 
   private normalizeSkillIds(value?: string[]) {
@@ -2480,10 +2570,99 @@ export class Handler {
     );
   }
 
+  private toProfileSystemMessage(props: {
+    language: string;
+    replyProfile: ISocialModuleProfile;
+  }): IOpenRouterRequestMessage {
+    const profileTitle =
+      this.getLocalizedProfileText(props.replyProfile.title, props.language) ||
+      props.replyProfile.adminTitle ||
+      props.replyProfile.slug;
+    const profileSubtitle = this.getLocalizedProfileText(
+      props.replyProfile.subtitle,
+      props.language,
+    );
+    const profileDescription = this.getLocalizedProfileText(
+      props.replyProfile.description,
+      props.language,
+    );
+
+    return {
+      role: "system",
+      content: [
+        "You are replying as a SinglePageStartup social profile specialist.",
+        `Profile slug: ${props.replyProfile.slug}.`,
+        `Profile title: ${profileTitle}.`,
+        profileSubtitle ? `Profile subtitle: ${profileSubtitle}.` : "",
+        profileDescription
+          ? ["Profile description and expertise:", profileDescription].join(
+              "\n",
+            )
+          : "",
+        "Use the profile description as persona, expertise, and communication boundary.",
+        "Do not treat selected social skills as part of the profile unless they are attached to the current user message.",
+      ]
+        .filter(Boolean)
+        .join("\n"),
+    };
+  }
+
+  private getLocalizedProfileText(value: unknown, language: string) {
+    if (typeof value === "string") {
+      return value.trim();
+    }
+
+    if (!value || typeof value !== "object" || Array.isArray(value)) {
+      return "";
+    }
+
+    const record = value as Record<string, unknown>;
+    const languageKeys = this.getProfileLanguageKeys(language);
+
+    for (const key of languageKeys) {
+      const localizedValue = record[key];
+
+      if (typeof localizedValue === "string" && localizedValue.trim()) {
+        return localizedValue.trim();
+      }
+    }
+
+    for (const fallbackKey of ["ru", "en"]) {
+      const fallbackValue = record[fallbackKey];
+
+      if (typeof fallbackValue === "string" && fallbackValue.trim()) {
+        return fallbackValue.trim();
+      }
+    }
+
+    for (const localizedValue of Object.values(record)) {
+      if (typeof localizedValue === "string" && localizedValue.trim()) {
+        return localizedValue.trim();
+      }
+    }
+
+    return "";
+  }
+
+  private getProfileLanguageKeys(language: string) {
+    const normalizedLanguage = this.toLearnText(language).toLowerCase();
+
+    if (["ru", "rus", "russian", "русский"].includes(normalizedLanguage)) {
+      return ["ru", "en"];
+    }
+
+    if (["en", "eng", "english", "английский"].includes(normalizedLanguage)) {
+      return ["en", "ru"];
+    }
+
+    return [normalizedLanguage, normalizedLanguage.slice(0, 2)].filter(Boolean);
+  }
+
   protected buildGenerationContext(props: {
     context: IOpenRouterRequestMessage[];
     expectedOutputModality: TOutputModality;
     language: string;
+    profileSystemMessage?: IOpenRouterRequestMessage;
     prependedSystemMessages?: IOpenRouterRequestMessage[];
   }): IOpenRouterRequestMessage[] {
     if (props.expectedOutputModality === "image") {
@@ -2503,6 +2682,7 @@ export class Handler {
             "Return image output.",
           ].join(" "),
         },
+        ...(props.profileSystemMessage ? [props.profileSystemMessage] : []),
         ...(props.prependedSystemMessages || []),
         {
           role: "user",
@@ -2528,6 +2708,7 @@ export class Handler {
         role: "system",
         content: "Return a text response only.",
       },
+      ...(props.profileSystemMessage ? [props.profileSystemMessage] : []),
       ...(props.prependedSystemMessages || []),
       {
         role: "user",

--- a/libs/modules/rbac/models/subject/frontend/component/src/lib/singlepage/social-module/profile/chat/message/list/default/ClientComponent.spec.tsx
+++ b/libs/modules/rbac/models/subject/frontend/component/src/lib/singlepage/social-module/profile/chat/message/list/default/ClientComponent.spec.tsx
@@ -512,10 +512,10 @@ describe("Given: OpenRouter chat profile sidebar", () => {
   /**
    * BDD Scenario
    * Given: the Knowledge assistant profile has a linked skill.
-   * When: the user mentions that skill with @ and submits a Knowledge chat message.
+   * When: the user invokes that skill with / and submits a Knowledge chat message.
    * Then: the selected skill id is passed to the OpenRouter reaction endpoint.
    */
-  it("When: mentioning a linked skill Then: Knowledge generation receives selected skill ids", async () => {
+  it("When: invoking a linked skill Then: Knowledge generation receives selected skill ids", async () => {
     mockChatComponentState.profileSkillRelations = [
       {
         id: "profile-skill-1",
@@ -536,7 +536,7 @@ describe("Given: OpenRouter chat profile sidebar", () => {
     mockMessageCreateMutate.mockImplementation((_payload, options) => {
       options?.onSuccess?.({
         id: "message-1",
-        description: "@brief-writer What should we answer?",
+        description: "/brief-writer What should we answer?",
       });
     });
 
@@ -545,17 +545,17 @@ describe("Given: OpenRouter chat profile sidebar", () => {
     const textarea = screen.getByPlaceholderText("Write a message...");
     fireEvent.change(textarea, {
       target: {
-        value: "@br",
+        value: "/br",
       },
     });
     fireEvent.click(screen.getByText("Brief Writer"));
 
-    expect((textarea as HTMLTextAreaElement).value).toBe("@brief-writer ");
-    expect(screen.getByText("brief-writer")).toBeTruthy();
+    expect((textarea as HTMLTextAreaElement).value).toBe("/brief-writer ");
+    expect(screen.getByLabelText("Remove brief-writer")).toBeTruthy();
 
     fireEvent.change(textarea, {
       target: {
-        value: "@brief-writer What should we answer?",
+        value: "/brief-writer What should we answer?",
       },
     });
     fireEvent.click(screen.getByLabelText("Send message"));
@@ -600,11 +600,11 @@ describe("Given: OpenRouter chat profile sidebar", () => {
 
   /**
    * BDD Scenario
-   * Given: the user selected a linked skill through the @ picker.
-   * When: the user removes that @skill mention from the composer text.
+   * Given: the user selected a linked skill through the / picker.
+   * When: the user removes that /skill command from the composer text.
    * Then: the selected skill badge is removed and the OpenRouter reaction does not receive stale skill ids.
    */
-  it("When: removing a typed skill mention Then: the selected skill badge is removed", async () => {
+  it("When: removing a typed skill command Then: the selected skill badge is removed", async () => {
     mockChatComponentState.profileSkillRelations = [
       {
         id: "profile-skill-1",
@@ -634,7 +634,7 @@ describe("Given: OpenRouter chat profile sidebar", () => {
     const textarea = screen.getByPlaceholderText("Write a message...");
     fireEvent.change(textarea, {
       target: {
-        value: "@br",
+        value: "/br",
       },
     });
     fireEvent.click(screen.getByText("Brief Writer"));
@@ -685,11 +685,11 @@ describe("Given: OpenRouter chat profile sidebar", () => {
 
   /**
    * BDD Scenario
-   * Given: the mention picker contains @knowledge and a linked skill.
+   * Given: the slash picker contains /learn and a linked skill.
    * When: the user navigates the picker with ArrowDown and presses Tab.
-   * Then: the active mention option is inserted into the composer.
+   * Then: the active slash option is inserted into the composer.
    */
-  it("When: selecting a mention option with arrows and Tab Then: it fills the composer", () => {
+  it("When: selecting a slash option with arrows and Tab Then: it fills the composer", () => {
     mockChatComponentState.profileSkillRelations = [
       {
         id: "profile-skill-1",
@@ -713,11 +713,11 @@ describe("Given: OpenRouter chat profile sidebar", () => {
     const textarea = screen.getByPlaceholderText("Write a message...");
     fireEvent.change(textarea, {
       target: {
-        value: "@kn",
+        value: "/",
       },
     });
 
-    expect(screen.getByText("Knowledge")).toBeTruthy();
+    expect(screen.getByText("/learn")).toBeTruthy();
     expect(screen.getByText("Knowledge Helper")).toBeTruthy();
     expect(
       screen
@@ -740,17 +740,17 @@ describe("Given: OpenRouter chat profile sidebar", () => {
       key: "Tab",
     });
 
-    expect((textarea as HTMLTextAreaElement).value).toBe("@knowledge-helper ");
+    expect((textarea as HTMLTextAreaElement).value).toBe("/knowledge-helper ");
     expect(document.activeElement).toBe(textarea);
   });
 
   /**
    * BDD Scenario
    * Given: a default chat has chat-gpt-1 as an AI opponent with a linked skill.
-   * When: the user opens the mention picker.
+   * When: the user opens the slash picker.
    * Then: the skill from chat-gpt-1 is shown in that default chat.
    */
-  it("When: opening mentions in an AI default chat Then: chat-gpt-1 skills are shown", () => {
+  it("When: opening slash commands in an AI default chat Then: chat-gpt-1 skills are shown", () => {
     mockChatComponentState.profileSkillRelations = [
       {
         id: "profile-skill-1",
@@ -775,7 +775,7 @@ describe("Given: OpenRouter chat profile sidebar", () => {
 
     fireEvent.change(screen.getByPlaceholderText("Write a message..."), {
       target: {
-        value: "@",
+        value: "/",
       },
     });
 
@@ -855,10 +855,10 @@ describe("Given: OpenRouter chat profile sidebar", () => {
   /**
    * BDD Scenario
    * Given: the Knowledge assistant profile has a linked skill.
-   * When: the user mentions @knowledge and a linked skill.
+   * When: the user mentions @knowledge and invokes a linked skill.
    * Then: the OpenRouter reaction endpoint combines RAG search with selected skill instructions.
    */
-  it("When: mentioning @knowledge and a linked skill Then: RAG and selected skills are combined", async () => {
+  it("When: mentioning @knowledge and invoking a linked skill Then: RAG and selected skills are combined", async () => {
     mockChatComponentState.profileSkillRelations = [
       {
         id: "profile-skill-1",
@@ -879,7 +879,7 @@ describe("Given: OpenRouter chat profile sidebar", () => {
     mockMessageCreateMutate.mockImplementation((_payload, options) => {
       options?.onSuccess?.({
         id: "message-1",
-        description: "@knowledge @brief-writer What should we answer?",
+        description: "@knowledge /brief-writer What should we answer?",
       });
     });
 
@@ -894,20 +894,20 @@ describe("Given: OpenRouter chat profile sidebar", () => {
     fireEvent.click(screen.getByText("Knowledge"));
     fireEvent.change(textarea, {
       target: {
-        value: "@knowledge @br",
+        value: "@knowledge /br",
       },
     });
     fireEvent.click(screen.getByText("Brief Writer"));
 
     expect((textarea as HTMLTextAreaElement).value).toBe(
-      "@knowledge @brief-writer ",
+      "@knowledge /brief-writer ",
     );
     expect(screen.getByText("@knowledge")).toBeTruthy();
-    expect(screen.getByText("brief-writer")).toBeTruthy();
+    expect(screen.getByLabelText("Remove brief-writer")).toBeTruthy();
 
     fireEvent.change(textarea, {
       target: {
-        value: "@knowledge @brief-writer What should we answer?",
+        value: "@knowledge /brief-writer What should we answer?",
       },
     });
     fireEvent.click(screen.getByLabelText("Send message"));
@@ -1017,7 +1017,7 @@ describe("Given: OpenRouter chat profile sidebar", () => {
   /**
    * BDD Scenario
    * Given: the Knowledge assistant profile has a linked skill.
-   * When: the user opens the @ picker and selects the skill.
+   * When: the user opens the / picker and selects the skill.
    * Then: the composer exposes only mention selection and removal, not skill editing.
    */
   it("When: using a linked skill in the composer Then: it does not expose skill editing", () => {
@@ -1050,7 +1050,7 @@ describe("Given: OpenRouter chat profile sidebar", () => {
 
     fireEvent.change(screen.getByPlaceholderText("Write a message..."), {
       target: {
-        value: "@br",
+        value: "/br",
       },
     });
 

--- a/libs/modules/rbac/models/subject/frontend/component/src/lib/singlepage/social-module/profile/chat/message/list/default/components/Composer.tsx
+++ b/libs/modules/rbac/models/subject/frontend/component/src/lib/singlepage/social-module/profile/chat/message/list/default/components/Composer.tsx
@@ -120,7 +120,7 @@ export function Composer(props: ComposerProps) {
     props.registerFocusComposerTextArea(composer.focusComposerTextArea);
   }, [composer.focusComposerTextArea, props.registerFocusComposerTextArea]);
 
-  // Keeps selected skills in sync with typed @mentions. The skill-selection
+  // Keeps selected skills in sync with typed /skill commands. The skill-selection
   // state lives in the shell, but its setter bails out when nothing changed,
   // so plain typing does not rerender the shell.
   useEffect(() => {
@@ -186,11 +186,11 @@ export function Composer(props: ComposerProps) {
       );
     });
   }, [commandQuery, knowledgeCommandMatch, props.canUseKnowledge]);
-  const isKnowledgeCommandPickerOpen =
-    props.canUseKnowledge && Boolean(knowledgeCommandMatch);
-  const visibleSkillMentionOptions = useMemo(() => {
+  const visibleSlashSkillOptions = useMemo(() => {
     return filterSkillMentionOptions(props.profileSkills, description);
   }, [description, props.profileSkills]);
+  const isKnowledgeCommandPickerOpen =
+    props.canUseKnowledge && Boolean(knowledgeCommandMatch);
   const visibleKnowledgeMentionOption =
     props.canUseKnowledge && shouldShowKnowledgeMentionOption(description)
       ? knowledgeMentionOption
@@ -199,29 +199,22 @@ export function Composer(props: ComposerProps) {
   const isSkillMentionPickerOpen =
     Boolean(getSkillMentionMatch(description)) && !isKnowledgeCommandPickerOpen;
 
-  const knowledgeCommandCount = visibleKnowledgeChatCommands.length;
-  const skillMentionOptionCount =
-    (visibleKnowledgeMentionOption ? 1 : 0) + visibleSkillMentionOptions.length;
+  const knowledgeCommandCount =
+    visibleKnowledgeChatCommands.length + visibleSlashSkillOptions.length;
+  const skillMentionOptionCount = visibleKnowledgeMentionOption ? 1 : 0;
   const visibleKnowledgeCommandSignature = useMemo(() => {
-    return visibleKnowledgeChatCommands
-      .map((command) => command.value)
-      .join(":");
-  }, [visibleKnowledgeChatCommands]);
-  const visibleSkillMentionOptionSignature = useMemo(() => {
-    return visibleSkillMentionOptions.map((skill) => skill.id).join(":");
-  }, [visibleSkillMentionOptions]);
-
+    return [
+      ...visibleKnowledgeChatCommands.map((command) => command.value),
+      ...visibleSlashSkillOptions.map((skill) => skill.id),
+    ].join(":");
+  }, [visibleKnowledgeChatCommands, visibleSlashSkillOptions]);
   useEffect(() => {
     setActiveKnowledgeCommandIndex(0);
   }, [isKnowledgeCommandPickerOpen, visibleKnowledgeCommandSignature]);
 
   useEffect(() => {
     setActiveSkillMentionOptionIndex(0);
-  }, [
-    isSkillMentionPickerOpen,
-    visibleKnowledgeMentionOption?.slug,
-    visibleSkillMentionOptionSignature,
-  ]);
+  }, [isSkillMentionPickerOpen, visibleKnowledgeMentionOption?.slug]);
 
   function selectKnowledgeCommand(commandValue: string) {
     const currentDescription = composer.form.getValues("description") || "";
@@ -238,6 +231,21 @@ export function Composer(props: ComposerProps) {
         )}${resolvedCommandValue} `
       : `${currentDescription.trimEnd()} ${resolvedCommandValue} `.trimStart();
 
+    composer.form.setValue("description", nextDescription, {
+      shouldDirty: true,
+      shouldValidate: true,
+    });
+    composer.focusComposerTextArea();
+  }
+
+  function selectSkillMention(skill: SocialSkill) {
+    const currentDescription = composer.form.getValues("description") || "";
+    const currentMatch = getKnowledgeCommandMatch(currentDescription);
+    const nextDescription = currentMatch
+      ? `${currentDescription.slice(0, currentMatch.startIndex)}/${skill.slug} `
+      : `${currentDescription.trimEnd()} /${skill.slug} `.trimStart();
+
+    props.onSkillSelect(skill);
     composer.form.setValue("description", nextDescription, {
       shouldDirty: true,
       shouldValidate: true,
@@ -270,6 +278,29 @@ export function Composer(props: ComposerProps) {
       shouldDirty: true,
       shouldValidate: true,
     });
+    composer.focusComposerTextArea();
+  }
+
+  function removeSelectedSkill(skillId: string) {
+    const skill = props.profileSkills.find((item) => {
+      return item.id === skillId;
+    });
+
+    if (skill) {
+      const currentDescription = composer.form.getValues("description") || "";
+      const escapedSlug = skill.slug.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+      const nextDescription = currentDescription
+        .replace(new RegExp(`(^|\\s)/${escapedSlug}(?=\\s|$)\\s*`, "i"), "$1")
+        .replace(/\s{2,}/g, " ")
+        .trimStart();
+
+      composer.form.setValue("description", nextDescription, {
+        shouldDirty: true,
+        shouldValidate: true,
+      });
+    }
+
+    props.onRemoveSelectedSkill(skillId);
     composer.focusComposerTextArea();
   }
 
@@ -328,21 +359,6 @@ export function Composer(props: ComposerProps) {
     }
   }
 
-  function selectSkillMention(skill: SocialSkill) {
-    const currentDescription = composer.form.getValues("description") || "";
-    const currentMatch = getSkillMentionMatch(currentDescription);
-    const nextDescription = currentMatch
-      ? `${currentDescription.slice(0, currentMatch.startIndex)}@${skill.slug} `
-      : `${currentDescription.trimEnd()} @${skill.slug} `;
-
-    props.onSkillSelect(skill);
-    composer.form.setValue("description", nextDescription, {
-      shouldDirty: true,
-      shouldValidate: true,
-    });
-    composer.focusComposerTextArea();
-  }
-
   const selectActiveSkillMentionOption = useCallback(() => {
     if (!isSkillMentionPickerOpen || skillMentionOptionCount <= 0) {
       return false;
@@ -353,22 +369,12 @@ export function Composer(props: ComposerProps) {
       return true;
     }
 
-    const skillIndex =
-      activeSkillMentionOptionIndex - (visibleKnowledgeMentionOption ? 1 : 0);
-    const skill = visibleSkillMentionOptions[skillIndex];
-
-    if (!skill) {
-      return false;
-    }
-
-    selectSkillMention(skill);
-    return true;
+    return false;
   }, [
     activeSkillMentionOptionIndex,
     isSkillMentionPickerOpen,
     skillMentionOptionCount,
     visibleKnowledgeMentionOption,
-    visibleSkillMentionOptions,
   ]);
 
   const selectActiveKnowledgeCommand = useCallback(() => {
@@ -378,17 +384,28 @@ export function Composer(props: ComposerProps) {
 
     const command = visibleKnowledgeChatCommands[activeKnowledgeCommandIndex];
 
-    if (!command) {
+    if (command) {
+      selectKnowledgeCommand(command.insertValue || command.value);
+      return true;
+    }
+
+    const skill =
+      visibleSlashSkillOptions[
+        activeKnowledgeCommandIndex - visibleKnowledgeChatCommands.length
+      ];
+
+    if (!skill) {
       return false;
     }
 
-    selectKnowledgeCommand(command.insertValue || command.value);
+    selectSkillMention(skill);
     return true;
   }, [
     activeKnowledgeCommandIndex,
     isKnowledgeCommandPickerOpen,
     knowledgeCommandCount,
     visibleKnowledgeChatCommands,
+    visibleSlashSkillOptions,
   ]);
 
   function onComposerTextareaKeyDown(
@@ -564,15 +581,18 @@ export function Composer(props: ComposerProps) {
           onOpenFile={openSelectedFile}
           onRemoveKnowledgeSearch={removeKnowledgeMention}
           onRemoveFile={removeSelectedFile}
-          onRemoveSkill={props.onRemoveSelectedSkill}
+          onRemoveSkill={removeSelectedSkill}
         />
         {isKnowledgeCommandPickerOpen ? (
           <KnowledgeCommandPicker
             activeIndex={activeKnowledgeCommandIndex}
             commands={visibleKnowledgeChatCommands}
+            language={props.language}
             onSelect={(command) => {
               selectKnowledgeCommand(command.insertValue || command.value);
             }}
+            onSkillSelect={selectSkillMention}
+            skills={visibleSlashSkillOptions}
           />
         ) : null}
         {isSkillMentionPickerOpen ? (
@@ -581,7 +601,7 @@ export function Composer(props: ComposerProps) {
             isLoading={props.isSkillOptionsLoading}
             knowledgeOption={visibleKnowledgeMentionOption}
             language={props.language}
-            skills={visibleSkillMentionOptions}
+            skills={[]}
             onKnowledgeSelect={selectKnowledgeMention}
             onSelect={selectSkillMention}
           />

--- a/libs/modules/rbac/models/subject/frontend/component/src/lib/singlepage/social-module/profile/chat/message/list/default/components/KnowledgeCommandPicker.tsx
+++ b/libs/modules/rbac/models/subject/frontend/component/src/lib/singlepage/social-module/profile/chat/message/list/default/components/KnowledgeCommandPicker.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { KnowledgeChatCommand } from "../types";
+import { KnowledgeChatCommand, SocialSkill } from "../types";
+import { Component as SocialModuleSkillChatMentionOption } from "@sps/social/models/skill/frontend/component/src/lib/singlepage/chat-mention-option";
 import { cn } from "@sps/shared-frontend-client-utils";
 import {
   Command,
@@ -14,15 +15,21 @@ import { BookOpenCheck } from "lucide-react";
 interface KnowledgeCommandPickerProps {
   activeIndex: number;
   commands: KnowledgeChatCommand[];
+  language: string;
   onSelect: (command: KnowledgeChatCommand) => void;
+  onSkillSelect: (skill: SocialSkill) => void;
+  skills: SocialSkill[];
 }
 
 export function KnowledgeCommandPicker(props: KnowledgeCommandPickerProps) {
+  const hasOptions = props.commands.length > 0 || props.skills.length > 0;
+  const skillOptionOffset = props.commands.length;
+
   return (
     <div className="mx-auto mb-2 w-full max-w-4xl rounded-lg border border-slate-200 bg-white p-1 shadow-lg">
       <Command shouldFilter={false} className="bg-transparent">
         <CommandList className="max-h-56">
-          {props.commands.length ? (
+          {hasOptions ? (
             <CommandGroup>
               {props.commands.map((command, commandIndex) => {
                 return (
@@ -54,10 +61,37 @@ export function KnowledgeCommandPicker(props: KnowledgeCommandPickerProps) {
                   </CommandItem>
                 );
               })}
+              {props.skills.map((skill, skillIndex) => {
+                const optionIndex = skillOptionOffset + skillIndex;
+
+                return (
+                  <CommandItem
+                    key={skill.id}
+                    value={skill.slug}
+                    onSelect={() => {
+                      props.onSkillSelect(skill);
+                    }}
+                    className={cn(
+                      "flex cursor-pointer items-start gap-3 rounded-md px-3 py-2",
+                      props.activeIndex === optionIndex
+                        ? "!bg-slate-100 data-[selected=true]:!bg-slate-100"
+                        : "bg-transparent data-[selected=true]:!bg-transparent",
+                    )}
+                  >
+                    <SocialModuleSkillChatMentionOption
+                      isServer={false}
+                      variant="chat-mention-option"
+                      data={skill}
+                      language={props.language}
+                      mentionPrefix="/"
+                    />
+                  </CommandItem>
+                );
+              })}
             </CommandGroup>
           ) : (
             <CommandEmpty className="py-6 text-center text-xs text-slate-500">
-              No commands found
+              No commands or skills found
             </CommandEmpty>
           )}
         </CommandList>

--- a/libs/modules/rbac/models/subject/frontend/component/src/lib/singlepage/social-module/profile/chat/message/list/default/utils.ts
+++ b/libs/modules/rbac/models/subject/frontend/component/src/lib/singlepage/social-module/profile/chat/message/list/default/utils.ts
@@ -113,7 +113,7 @@ export function filterSkillMentionOptions(
   profileSkills: SocialSkill[],
   description?: string | null,
 ) {
-  const skillMentionMatch = getSkillMentionMatch(description);
+  const skillMentionMatch = getKnowledgeCommandMatch(description);
 
   if (!skillMentionMatch) {
     return [];
@@ -153,11 +153,15 @@ export function hasKnowledgeMention(value?: string | null) {
 }
 
 export function getMentionedSkillSlugs(value?: string | null) {
-  const matches = (value || "").matchAll(/(^|\s)@([a-zA-Z0-9._-]+)(?=\s|$)/g);
+  const matches = (value || "").matchAll(/(^|\s)\/([a-zA-Z0-9._-]+)(?=\s|$)/g);
 
   return new Set(
-    Array.from(matches).map((match) => {
-      return match[2].toLowerCase();
-    }),
+    Array.from(matches)
+      .map((match) => {
+        return match[2].toLowerCase();
+      })
+      .filter((slug) => {
+        return !["learn", "new"].includes(slug);
+      }),
   );
 }

--- a/libs/modules/social/models/skill/frontend/component/src/lib/singlepage/chat-mention-option/Component.tsx
+++ b/libs/modules/social/models/skill/frontend/component/src/lib/singlepage/chat-mention-option/Component.tsx
@@ -8,6 +8,7 @@ function getSkillTitle(skill: IComponentPropsExtended["data"]) {
 
 export function Component(props: IComponentPropsExtended) {
   const canEditOnClick = Boolean(props.editOnClick && props.onEdit);
+  const mentionPrefix = props.mentionPrefix || "@";
   const content = (
     <>
       <Package className="mt-0.5 h-4 w-4 shrink-0 text-slate-500" />
@@ -16,7 +17,8 @@ export function Component(props: IComponentPropsExtended) {
           {getSkillTitle(props.data)}
         </span>
         <span className="block truncate text-xs text-slate-500">
-          @{props.data.slug}
+          {mentionPrefix}
+          {props.data.slug}
         </span>
       </span>
       {props.onEdit && !props.editOnClick ? (

--- a/libs/modules/social/models/skill/frontend/component/src/lib/singlepage/chat-mention-option/interface.ts
+++ b/libs/modules/social/models/skill/frontend/component/src/lib/singlepage/chat-mention-option/interface.ts
@@ -9,6 +9,7 @@ export interface IClientComponentProps
   data: IModel;
   language: string;
   editOnClick?: boolean;
+  mentionPrefix?: "@" | "/";
   onEdit?: (skill: IModel) => void;
 }
 

--- a/libs/modules/social/models/skill/frontend/component/src/lib/singlepage/chat-selected-pill/ClientComponent.tsx
+++ b/libs/modules/social/models/skill/frontend/component/src/lib/singlepage/chat-selected-pill/ClientComponent.tsx
@@ -2,7 +2,7 @@
 
 import { IClientComponentProps } from "./interface";
 import { cn } from "@sps/shared-frontend-client-utils";
-import { AtSign, Pencil, X } from "lucide-react";
+import { Pencil, Slash, X } from "lucide-react";
 
 export function Component(props: IClientComponentProps) {
   return (
@@ -16,8 +16,8 @@ export function Component(props: IClientComponentProps) {
         props.className,
       )}
     >
-      <AtSign className="h-3 w-3 shrink-0" />
-      <span className="truncate">{props.data.slug}</span>
+      <Slash className="h-3 w-3 shrink-0" />
+      <span className="truncate">/{props.data.slug}</span>
       {props.onEdit ? (
         <button
           type="button"

--- a/libs/modules/social/models/skill/frontend/component/src/lib/singlepage/chat-sidebar-item/Component.tsx
+++ b/libs/modules/social/models/skill/frontend/component/src/lib/singlepage/chat-sidebar-item/Component.tsx
@@ -35,9 +35,9 @@ export function Component(props: IComponentPropsExtended) {
         </span>
         <span
           className="mt-0.5 block max-w-full truncate text-[11px] text-slate-400"
-          title={`@${props.data.slug}`}
+          title={`/${props.data.slug}`}
         >
-          @{props.data.slug}
+          /{props.data.slug}
         </span>
       </span>
     </button>

--- a/thoughts/shared/handoffs/singlepagestartup/ISSUE-193-progress.md
+++ b/thoughts/shared/handoffs/singlepagestartup/ISSUE-193-progress.md
@@ -1,0 +1,42 @@
+---
+date: 2026-06-15T00:00:00Z
+issue_number: 193
+repository: singlepagestartup
+branch: codex/issue-193-openrouter-skill-prefix
+status: in_progress
+---
+
+# ISSUE-193 Implementation Progress
+
+## Current Objective
+
+Implement OpenRouter-compatible SPS skills as text instructions attached to the beginning of the triggering user message, with slash invocation scoped to active skills linked to the replying profile.
+
+## Progress
+
+- Created implementation branch `codex/issue-193-openrouter-skill-prefix`.
+- Synchronized GitHub issue comments through `2026-06-14T23:10:50Z`.
+- Updated process log to mark corrected implementation in progress.
+- Updated `react-by/openrouter` so slash-invoked linked profile skills are expanded into the triggering user message prefix instead of system context.
+- Added profile persona system context from the replying `social.profile`.
+- Kept `@knowledge` as the RAG switch and `/learn` as a reserved command.
+- Updated composer command handling so `/` shows `/learn` plus linked active profile skills; `@` remains scoped to `@knowledge`.
+- Updated `social.skill` chat display variants to show slash invocation (`/skill-slug`) where the skill is used as a chat command.
+
+## Verification
+
+- Passed: `npx nx run @sps/rbac:jest:test --testFile=libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/find-by-id/message/react-by-openrouter.spec.ts`.
+- Passed: `npx nx run @sps/rbac:jest:test --testFile=libs/modules/rbac/models/subject/frontend/component/src/lib/singlepage/social-module/profile/chat/message/list/default/ClientComponent.spec.tsx`.
+- Passed: `npx nx run @sps/rbac:tsc:build`.
+- Passed Browser check on `http://localhost:3000/en/social/chats/55eea53b-d6d8-44ef-9fb5-14ad0d79031d`: `/` and `@knowledge /` list `/learn` and `/youtube-description`; ArrowDown+Tab inserts `/youtube-description`; deleting the slash skill clears the badge.
+
+## Notes
+
+- `npm run api:dev` was started for Browser verification and stopped after checks.
+- Opening the older user-provided `bdbd3330.../42e59...` URL produced a host page 404 because that page URL is no longer present in local data; verification used the available `RAG` AI chat instead.
+- The `npm run test:file -- <path>` helper script currently fails before running Jest because it calls `nx run` without a project. Direct `npx nx run @sps/rbac:jest:test --testFile=...` was used.
+
+## Next Steps
+
+- Commit the implementation branch.
+- Open a PR and submit it for code review.

--- a/thoughts/shared/handoffs/singlepagestartup/ISSUE-193-progress.md
+++ b/thoughts/shared/handoffs/singlepagestartup/ISSUE-193-progress.md
@@ -4,6 +4,8 @@ issue_number: 193
 repository: singlepagestartup
 branch: codex/issue-193-openrouter-skill-prefix
 status: in_progress
+pr_number: 198
+pr_url: https://github.com/singlepagestartup/singlepagestartup/pull/198
 ---
 
 # ISSUE-193 Implementation Progress
@@ -38,5 +40,4 @@ Implement OpenRouter-compatible SPS skills as text instructions attached to the 
 
 ## Next Steps
 
-- Commit the implementation branch.
-- Open a PR and submit it for code review.
+- Submit PR #198 for code review through `.claude/helpers/submit_pr_for_code_review.sh`.

--- a/thoughts/shared/handoffs/singlepagestartup/ISSUE-193-progress.md
+++ b/thoughts/shared/handoffs/singlepagestartup/ISSUE-193-progress.md
@@ -3,7 +3,8 @@ date: 2026-06-15T00:00:00Z
 issue_number: 193
 repository: singlepagestartup
 branch: codex/issue-193-openrouter-skill-prefix
-status: in_progress
+status: complete
+completed_date: 2026-06-15T00:00:00Z
 pr_number: 198
 pr_url: https://github.com/singlepagestartup/singlepagestartup/pull/198
 ---
@@ -38,6 +39,8 @@ Implement OpenRouter-compatible SPS skills as text instructions attached to the 
 - Opening the older user-provided `bdbd3330.../42e59...` URL produced a host page 404 because that page URL is no longer present in local data; verification used the available `RAG` AI chat instead.
 - The `npm run test:file -- <path>` helper script currently fails before running Jest because it calls `nx run` without a project. Direct `npx nx run @sps/rbac:jest:test --testFile=...` was used.
 
-## Next Steps
+## Summary
 
-- Submit PR #198 for code review through `.claude/helpers/submit_pr_for_code_review.sh`.
+- Implementation complete.
+- PR: https://github.com/singlepagestartup/singlepagestartup/pull/198.
+- Awaiting code review.

--- a/thoughts/shared/plans/singlepagestartup/ISSUE-193.md
+++ b/thoughts/shared/plans/singlepagestartup/ISSUE-193.md
@@ -313,4 +313,4 @@ No database migration is required. Existing `social.skill`, `profiles-to-skills`
 - Process log: `thoughts/shared/processes/singlepagestartup/ISSUE-193.md`
 - Related baseline research: `thoughts/shared/research/singlepagestartup/ISSUE-192.md`
 
-<!-- Last synced at: 2026-06-14T23:07:15Z -->
+<!-- Last synced at: 2026-06-14T23:10:50Z -->

--- a/thoughts/shared/plans/singlepagestartup/ISSUE-193.md
+++ b/thoughts/shared/plans/singlepagestartup/ISSUE-193.md
@@ -1,0 +1,316 @@
+---
+date: 2026-06-15T01:01:43+0300
+issue_number: 193
+repository: singlepagestartup
+topic: "OpenRouter message-attached social skill instructions"
+status: in_review
+---
+
+# OpenRouter Message-Attached Social Skill Instructions Implementation Plan
+
+## Overview
+
+Update `react-by/openrouter` so `social.skill` records linked to the replying profile work as SPS-managed text instructions attached to the beginning of the triggering user message. Skills are invoked in chat with slash syntax using the linked skill slug, for example `/youtube-description`; the replying AI profile description becomes the system/persona context, and `@knowledge` continues to add profile-scoped RAG fragments.
+
+## Current State Analysis
+
+Issue #193 originally requested provider-native OpenAI/Anthropic Skills, but the corrected research and operator clarification supersede that scope for OpenRouter. OpenRouter skills are now planned as text instructions, not native provider skill mounts.
+
+Current backend behavior already resolves linked active skills and `@knowledge`, but places selected skills into system messages:
+
+- `react-by-openrouter.ts` detects selected skill ids, `@knowledge`, mentioned skills, and computes the sanitized trigger query before loading the reply profile (`libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/find-by-id/message/react-by-openrouter.ts:884`).
+- The thread context builder already substitutes the persisted trigger message with `sanitizedTriggerDescription`, so the generated payload can differ from the saved `social.message.description` (`libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/find-by-id/message/react-by-openrouter.ts:971`).
+- String and multipart OpenRouter context messages are pushed in one place, which is the correct surface for attaching a skill prefix to the trigger user message (`libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/find-by-id/message/react-by-openrouter.ts:1080`).
+- `resolveOpenRouterKnowledgeContext(...)` currently returns `systemMessages` that include selected skills and RAG fragments (`libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/find-by-id/message/react-by-openrouter.ts:1618`).
+- `toSkillSystemPrompt(...)` formats selected skills for system-message injection today, which conflicts with the clarified requirement (`libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/find-by-id/message/react-by-openrouter.ts:1853`).
+- `buildGenerationContext(...)` prepends system messages before the thread context, so profile persona and RAG can remain system context while skill instructions move into the user message (`libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/find-by-id/message/react-by-openrouter.ts:2483`).
+- Current skill mention parsing uses `@slug` syntax and strips `@...` tokens (`libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/find-by-id/message/react-by-openrouter.ts:2215`); this must move to slash skill tokens while preserving reserved slash commands such as `/learn`.
+- `social.profile` already has localized `title`, `subtitle`, and `description` JSONB fields suitable for specialist/persona context (`libs/modules/social/models/profile/backend/repository/database/src/lib/fields/singlepage.ts:10`).
+- Legacy `react-by/knowledge` already treats the reply profile as persona by passing profile title and description into generation (`libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/find-by-id/message/react-by-knowledge.ts:673`), and Knowledge generation places persona context before skill/history/query sections (`libs/modules/knowledge/backend/app/api/src/lib/generation/index.ts:214`).
+
+## Desired End State
+
+When a user sends a message with `/skill-slug`, selected `skillIds`, or both, `react-by/openrouter` resolves only active skills linked to the replying AI profile and prefixes their instructions to the triggering user message in the OpenRouter request payload. A skill cannot be invoked if it is not already linked to that replying profile through `profiles-to-skills`. The saved user message remains unchanged. Reply profile description is added as system/persona context. `@knowledge` still controls whether profile-scoped RAG search runs and RAG fragments are added as grounding context. The current thread context continues to be included in the generation payload.
+
+Verification should prove the exact OpenRouter `messages` payload has:
+
+- System context for language/output rules.
+- System context for the replying AI profile/persona.
+- System context for RAG fragments only when `@knowledge` is present.
+- A user message whose content starts with selected skill instructions followed by the sanitized user request.
+- Current thread history before the trigger message, preserving the existing context behavior.
+- No selected skill instructions in system/developer messages.
+
+### Key Discoveries
+
+- The current trigger message can already be sanitized without mutating persisted message data (`react-by-openrouter.ts:971`).
+- Selected skills are already scoped through `profiles-to-skills`, ordered, deduplicated, and filtered for `status !== "archived"` (`react-by-openrouter.ts:1731`).
+- The current skill insertion point is wrong because `toSkillSystemPrompt(...)` returns a system prompt (`react-by-openrouter.ts:1853`).
+- The current `@skill` parser and stripper must be changed to slash skill syntax, while `/learn` remains a reserved command and not a skill slug.
+- RAG scoping already uses profile-linked Knowledge document ids before search (`react-by-openrouter.ts:1606`).
+- Frontend already submits selected `skillIds`, `useKnowledgeSearch`, OpenRouter `model`, and `reasoning` through the reaction request (`libs/modules/rbac/models/subject/frontend/component/src/lib/singlepage/social-module/profile/chat/message/list/default/hooks/use-chat-composer.ts:152`).
+
+## What We're NOT Doing
+
+- Not implementing provider-native OpenAI `skill_reference` or Anthropic `container.skills` through OpenRouter.
+- Not changing `social.skill`, `social.profile`, or relation database schemas.
+- Not changing the user-visible saved message content by storing injected skill instructions in `social.message.description`.
+- Not moving skill instructions into `system` or `developer` messages.
+- Not replacing `@knowledge` RAG behavior or `/learn` semantics.
+- Not adding a new OpenRouter tool-calling loop for skill activation in this pass.
+- Not allowing a message to invoke skills linked to another profile.
+- Not changing model or Thinking controls.
+
+## Implementation Approach
+
+Make the smallest backend change that separates three instruction layers:
+
+1. Profile/persona system context from the replying `social.profile`.
+2. Optional RAG system context from `@knowledge`.
+3. Optional selected skill prefix attached to the triggering user message.
+
+Keep the existing RBAC/frontend contract intact: the composer continues to pass `skillIds`, `useKnowledgeSearch`, `model`, and `reasoning`; the backend decides how those controls shape the OpenRouter payload.
+
+The frontend mention/command contract changes only for skills: skill invocation is slash-based (`/skill-slug`) and must be populated from the replying profile's linked active skills. `@knowledge` remains the Knowledge/RAG control mention.
+
+## Phase 1: Backend Context Contract
+
+### Overview
+
+Refactor `react-by/openrouter` context assembly so selected skills no longer become system messages and instead become a prefix on the trigger user message sent to OpenRouter.
+
+### Changes Required
+
+#### 1. OpenRouter Knowledge/Skill Resolution
+
+**File**: `libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/find-by-id/message/react-by-openrouter.ts`
+
+**Why**: `resolveOpenRouterKnowledgeContext(...)` currently mixes selected skill instructions and RAG fragments into one `systemMessages` array, which prevents enforcing distinct placement.
+
+**Changes**:
+
+- Split or reshape the resolved context so it exposes selected skills separately from RAG system messages.
+- Replace `toSkillSystemPrompt(...)` with a helper such as `toSkillMessagePrefix(...)`.
+- Resolve slash skill tokens such as `/youtube-description` against active skills linked to the replying profile.
+- Preserve linked-profile authorization, slug lookup, id lookup, archived filtering, and stable relation ordering.
+- Reject or ignore unlinked slash skill slugs clearly; do not fall back to global `social.skill` lookup.
+- Keep `/learn` reserved for Knowledge ingestion and exclude it from skill slug resolution.
+- Keep `requestedSkillIds`, `promptSkills`, and existing metadata inputs available for the assistant message metadata.
+
+### Success Criteria
+
+#### Automated Verification
+
+- [ ] Backend unit tests prove selected linked skills are still resolved and unlinked skill ids still fail.
+- [ ] Backend unit tests prove slash skill slugs resolve only through the replying profile's `profiles-to-skills` relations.
+- [ ] Backend unit tests prove archived skills are excluded.
+- [ ] Backend unit tests prove `/learn` is treated as a command, not a skill.
+
+#### Manual Verification
+
+- [ ] Code review confirms no selected skill content is returned inside `systemMessages`.
+
+---
+
+## Phase 2: Trigger Message Prefixing
+
+### Overview
+
+Attach selected skill instructions to the beginning of the triggering user message in the OpenRouter payload while leaving persisted chat message text unchanged.
+
+### Changes Required
+
+#### 1. Thread Context Builder
+
+**File**: `libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/find-by-id/message/react-by-openrouter.ts`
+
+**Why**: The message loop already knows when it is processing the trigger message and already substitutes the raw message with `sanitizedTriggerDescription`.
+
+**Changes**:
+
+- Apply the skill prefix only when `socialModuleMessage.id === socialModuleMessageId`.
+- For string content, prefix the sanitized trigger text.
+- For multipart content with attachments, prefix only the first text part while preserving image/file parts.
+- Strip slash skill tokens from the sanitized trigger text after resolving them, so the model receives the expanded skill instructions plus the user's actual request.
+- Do not prefix assistant messages, prior user messages, status messages, or `/new` reset markers.
+- Preserve the existing current-thread context that is already sent to OpenRouter; do not reduce generation to only the trigger message.
+- Keep `social.message.description` unchanged in creation/update paths.
+
+### Success Criteria
+
+#### Automated Verification
+
+- [ ] Backend test asserts generated OpenRouter context includes selected skill instructions at the start of the trigger user message.
+- [ ] Backend test asserts generated OpenRouter context does not include selected skill instructions in any system message.
+- [ ] Backend test asserts current thread history remains present in the OpenRouter payload.
+- [ ] Backend test covers trigger messages with file/image parts.
+
+#### Manual Verification
+
+- [ ] In the UI, the sent user message still displays the original `/skill-slug` request text, not the expanded instruction block.
+
+---
+
+## Phase 3: Profile Persona And RAG System Context
+
+### Overview
+
+Add the replying AI profile description as system/persona context and keep RAG fragments as separate system grounding only when `@knowledge` is requested.
+
+### Changes Required
+
+#### 1. Profile Persona Prompt
+
+**File**: `libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/find-by-id/message/react-by-openrouter.ts`
+
+**Why**: The user clarified that the profile itself represents the specialist. Its description belongs in system context, not in the user message.
+
+**Changes**:
+
+- Add a profile/persona system helper based on reply profile `adminTitle`, `slug`, localized `title`, and localized `description`.
+- Prefer the request language where it maps to profile text keys; otherwise fall back to available `ru`, `en`, or first non-empty localized value.
+- Add the persona system message to `buildGenerationContext(...)` before RAG fragments and before thread context.
+- Avoid duplicating skill descriptions in profile persona context; linked skills remain user-message prefix only when selected.
+
+#### 2. RAG Context Preservation
+
+**File**: `libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/find-by-id/message/react-by-openrouter.ts`
+
+**Why**: `@knowledge` must continue to pass profile-scoped search results into generation, and must still combine with selected skill instructions.
+
+**Changes**:
+
+- Keep Knowledge document lookup scoped to `profiles-to-knowledge-module-documents`.
+- Keep search disabled unless `@knowledge` or `useKnowledgeSearch` explicitly requests it.
+- Keep `/learn` requiring `@knowledge /learn`.
+- Keep RAG fragments in system context because they are grounding data, not user-request instructions.
+
+### Success Criteria
+
+#### Automated Verification
+
+- [ ] Backend test asserts reply profile description appears in system context.
+- [ ] Backend test asserts `@knowledge` still searches only linked document ids.
+- [ ] Backend test asserts no RAG search runs without `@knowledge`.
+- [ ] Backend test asserts selected skill prefix and RAG fragments can both appear in one request payload in their separate layers.
+
+#### Manual Verification
+
+- [ ] In an AI chat with a profile description, responses follow the profile persona even when no skill is selected.
+- [ ] In the same chat, adding `@knowledge` grounds the response in linked Knowledge documents.
+
+---
+
+## Phase 4: Metadata And Frontend Contract Preservation
+
+### Overview
+
+Keep the current frontend interaction model and make assistant metadata accurately describe applied skills as message-prefix instructions.
+
+### Changes Required
+
+#### 1. Assistant Message Metadata
+
+**File**: `libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/find-by-id/message/react-by-openrouter.ts`
+
+**Why**: Current metadata records selected skills as prompt instructions. After this change the placement is specifically the trigger user message prefix.
+
+**Changes**:
+
+- Store applied skill ids/slugs/titles in `message.metadata.knowledge.skills`.
+- Use a mode label such as `message-prefix-instruction`.
+- Preserve existing `useKnowledgeSearch`, `documentIds`, `sources`, selected model, and reasoning metadata.
+
+#### 2. Composer Request Contract
+
+**Files**:
+
+- `libs/modules/rbac/models/subject/frontend/component/src/lib/singlepage/social-module/profile/chat/message/list/default/hooks/use-chat-composer.ts`
+- `libs/modules/rbac/models/subject/frontend/component/src/lib/singlepage/social-module/profile/chat/message/list/default/components/Composer.tsx`
+- `libs/modules/rbac/models/subject/frontend/component/src/lib/singlepage/social-module/profile/chat/message/list/default/components/SkillMentionPicker.tsx`
+- `libs/modules/rbac/models/subject/frontend/component/src/lib/singlepage/social-module/profile/chat/message/list/default/hooks/use-profile-skills.ts`
+
+**Why**: The frontend already passes `skillIds`, `@knowledge`, model, and Thinking controls. It must switch skill insertion from `@skill` to `/skill-slug` while keeping skill options scoped to the replying profile.
+
+**Changes**:
+
+- Preserve current request body and query params.
+- Keep selected skill badges and selected skill id synchronization, but derive selected skills from slash skill tokens.
+- Show linked active profile skills in the slash picker; do not show global or other-profile skills.
+- Keep `/learn` in the command list and avoid collision with skills whose slug would conflict with reserved commands.
+- Keep `@knowledge` as the Knowledge/RAG control mention.
+- Confirm no code expands skill instructions into the visible textarea or saved message body.
+
+### Success Criteria
+
+#### Automated Verification
+
+- [ ] Frontend tests still prove selected skill ids are sent to `react-by/openrouter`.
+- [ ] Frontend tests still prove removing a skill mention clears stale `skillIds`.
+- [ ] Frontend tests still prove `@knowledge` sets `useKnowledgeSearch`.
+- [ ] Frontend tests prove `/skill-slug` selects a linked profile skill and no unlinked profile skill appears in the picker.
+- [ ] Frontend tests prove `/learn` remains available as a command and is not treated as a skill.
+
+#### Manual Verification
+
+- [ ] Selecting a skill through `/skill-slug` leaves the visible message compact but affects the model response.
+
+---
+
+## Testing Strategy
+
+### Unit Tests
+
+- Update `libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/find-by-id/message/react-by-openrouter.spec.ts`.
+- Add BDD coverage for skill prefix placement on string user messages.
+- Add BDD coverage for skill prefix placement on multipart user messages with attachments.
+- Add BDD coverage for profile persona system prompt.
+- Add BDD coverage for `/skill-slug` resolution from linked active profile skills.
+- Add BDD coverage for rejecting or clearly ignoring unlinked slash skill slugs.
+- Add BDD coverage for current thread context preservation.
+- Add BDD coverage for `@knowledge + /skill-slug` composition.
+- Keep existing manual model/reasoning tests unchanged unless payload setup changes.
+
+### Frontend Tests
+
+- Update `libs/modules/rbac/models/subject/frontend/component/src/lib/singlepage/social-module/profile/chat/message/list/default/ClientComponent.spec.tsx` only if request assertions need wording changes.
+- Preserve tests around selected skill badges, stale skill removal, `@knowledge`, `/learn`, model dropdown, and Thinking dropdown.
+- Update picker tests so slash input can show both reserved commands and linked profile skills, with `/learn` remaining a command and `/skill-slug` selecting a skill.
+
+### Automated Commands
+
+- [ ] `npm run test:file -- libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/find-by-id/message/react-by-openrouter.spec.ts`
+- [ ] `npm run test:file -- libs/modules/rbac/models/subject/frontend/component/src/lib/singlepage/social-module/profile/chat/message/list/default/ClientComponent.spec.tsx`
+- [ ] `npx nx run @sps/rbac:models:subject:backend-app-api:typescript:build`
+- [ ] `npx nx run @sps/rbac:models:subject:frontend-component:typescript:build`
+
+### Manual Testing Steps
+
+1. Start the backend yourself with `npm run api:dev` and keep the terminal open to inspect API logs during the test.
+2. Start the host with `npm run host:dev` if it is not already running.
+3. Use the Browser plugin against the already-authenticated in-app browser session.
+4. Open an AI chat where the reply profile has a description and at least one linked active skill.
+5. Type `/` and verify the picker shows `/learn` plus skills linked to the replying profile, and does not show skills from other profiles.
+6. Send `/skill-slug` with a normal text request and verify the answer follows the skill while the saved user message remains compact.
+7. Send `@knowledge /skill-slug` with a question covered by linked Knowledge documents and verify the answer uses both the skill behavior and profile-scoped RAG facts.
+8. Send the same question without `@knowledge` and verify RAG is not invoked.
+9. Send `@knowledge /learn ...` and verify learning still indexes/links Knowledge without OpenRouter generation.
+
+## Performance Considerations
+
+- Skill prefixing increases prompt size only for explicitly selected or mentioned skills.
+- RAG search remains disabled unless `@knowledge` is present, so non-RAG OpenRouter messages do not pay search cost.
+- Profile persona context is small and should be normalized/trimmed to avoid large localized JSON blobs in every request.
+
+## Migration Notes
+
+No database migration is required. Existing `social.skill`, `profiles-to-skills`, `social.profile.description`, and Knowledge relation data are reused. Existing provider-native sync metadata can remain in place but is not used by the OpenRouter text-skill path.
+
+## References
+
+- Original ticket: `thoughts/shared/tickets/singlepagestartup/ISSUE-193.md`
+- Corrected research: `thoughts/shared/research/singlepagestartup/ISSUE-193.md`
+- Process log: `thoughts/shared/processes/singlepagestartup/ISSUE-193.md`
+- Related baseline research: `thoughts/shared/research/singlepagestartup/ISSUE-192.md`
+
+<!-- Last synced at: 2026-06-14T23:07:15Z -->

--- a/thoughts/shared/processes/singlepagestartup/ISSUE-193.md
+++ b/thoughts/shared/processes/singlepagestartup/ISSUE-193.md
@@ -3,9 +3,9 @@ issue_number: 193
 issue_title: "feat: sync profile skills to provider-native AI Skills for Knowledge chats"
 repository: singlepagestartup
 created_at: 2026-06-04T20:44:33Z
-last_updated: 2026-06-14T23:07:15Z
+last_updated: 2026-06-15T00:00:00Z
 status: active
-current_phase: plan
+current_phase: implement
 ---
 
 # Process Log: ISSUE-193 - feat: sync profile skills to provider-native AI Skills for Knowledge chats
@@ -19,9 +19,9 @@ Tracks cross-phase execution notes, incidents, reusable fixes, and workflow lear
 - Create: completed
 - Research: completed
 - Plan: completed
-- Implement: completed_direct
-- Current phase: plan
-- Next step: human review, then core/30-implement
+- Implement: in_progress
+- Current phase: implement
+- Next step: complete implementation and submit PR for code review
 
 ## Phase Notes
 
@@ -53,6 +53,14 @@ Tracks cross-phase execution notes, incidents, reusable fixes, and workflow lear
 - Summary: Implemented provider-native profile skills sync and Knowledge chat usage directly from the user-provided plan.
 - Outputs: Added RBAC profile skill provider-sync endpoint, SDK actions, Knowledge `providerSkills` propagation, OpenAI/Anthropic gateway payload support, and focused tests.
 - Notes: This implementation bypassed the normal `core/10-research` and `core/20-plan` issue phases because the user explicitly requested direct implementation after the create artifact was produced. The previous plan was later invalidated; planning must restart from the corrected `react-by/openrouter` research.
+- Summary: Started corrected implementation from the approved OpenRouter message-attached skill plan.
+- Outputs: Implementation branch `codex/issue-193-openrouter-skill-prefix`.
+- Notes: GitHub comments were synchronized before coding; the only post-plan comment was the review clarification already applied in commit `f32c07a8d9`.
+- Summary: Implemented corrected OpenRouter slash-skill flow.
+- Outputs: `react-by/openrouter` now injects linked profile skills as a trigger-message prefix, adds profile persona as system context, keeps `@knowledge` RAG fragments as system grounding, and updates composer slash picker behavior.
+- Verification: `npx nx run @sps/rbac:jest:test --testFile=libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/find-by-id/message/react-by-openrouter.spec.ts`; `npx nx run @sps/rbac:jest:test --testFile=libs/modules/rbac/models/subject/frontend/component/src/lib/singlepage/social-module/profile/chat/message/list/default/ClientComponent.spec.tsx`; `npx nx run @sps/rbac:tsc:build`.
+- Verification: Browser checked `RAG` chat on `localhost:3000` with `npm run api:dev` logs. `/` and `@knowledge /` showed `/learn` plus linked `/youtube-description`, ArrowDown+Tab inserted `/youtube-description`, a single slash skill badge appeared, keyboard deletion cleared it, and no new API errors appeared during valid-page checks.
+- Notes: The planned `npm run test:file -- <path>` command is incompatible with the current Nx script because it invokes `nx run` without a project. Equivalent direct `npx nx run @sps/rbac:jest:test --testFile=...` commands were used.
 
 ## Incident Log
 

--- a/thoughts/shared/processes/singlepagestartup/ISSUE-193.md
+++ b/thoughts/shared/processes/singlepagestartup/ISSUE-193.md
@@ -5,7 +5,7 @@ repository: singlepagestartup
 created_at: 2026-06-04T20:44:33Z
 last_updated: 2026-06-15T00:00:00Z
 status: active
-current_phase: implement
+current_phase: complete
 ---
 
 # Process Log: ISSUE-193 - feat: sync profile skills to provider-native AI Skills for Knowledge chats
@@ -19,9 +19,9 @@ Tracks cross-phase execution notes, incidents, reusable fixes, and workflow lear
 - Create: completed
 - Research: completed
 - Plan: completed
-- Implement: in_progress
-- Current phase: implement
-- Next step: complete implementation and submit PR for code review
+- Implement: completed
+- Current phase: complete
+- Next step: code review / merge
 
 ## Phase Notes
 

--- a/thoughts/shared/processes/singlepagestartup/ISSUE-193.md
+++ b/thoughts/shared/processes/singlepagestartup/ISSUE-193.md
@@ -61,6 +61,7 @@ Tracks cross-phase execution notes, incidents, reusable fixes, and workflow lear
 - Verification: `npx nx run @sps/rbac:jest:test --testFile=libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/find-by-id/message/react-by-openrouter.spec.ts`; `npx nx run @sps/rbac:jest:test --testFile=libs/modules/rbac/models/subject/frontend/component/src/lib/singlepage/social-module/profile/chat/message/list/default/ClientComponent.spec.tsx`; `npx nx run @sps/rbac:tsc:build`.
 - Verification: Browser checked `RAG` chat on `localhost:3000` with `npm run api:dev` logs. `/` and `@knowledge /` showed `/learn` plus linked `/youtube-description`, ArrowDown+Tab inserted `/youtube-description`, a single slash skill badge appeared, keyboard deletion cleared it, and no new API errors appeared during valid-page checks.
 - Notes: The planned `npm run test:file -- <path>` command is incompatible with the current Nx script because it invokes `nx run` without a project. Equivalent direct `npx nx run @sps/rbac:jest:test --testFile=...` commands were used.
+- Outputs: Draft PR #198 https://github.com/singlepagestartup/singlepagestartup/pull/198.
 
 ## Incident Log
 

--- a/thoughts/shared/processes/singlepagestartup/ISSUE-193.md
+++ b/thoughts/shared/processes/singlepagestartup/ISSUE-193.md
@@ -3,9 +3,9 @@ issue_number: 193
 issue_title: "feat: sync profile skills to provider-native AI Skills for Knowledge chats"
 repository: singlepagestartup
 created_at: 2026-06-04T20:44:33Z
-last_updated: 2026-06-13T20:28:22Z
+last_updated: 2026-06-14T23:07:15Z
 status: active
-current_phase: research
+current_phase: plan
 ---
 
 # Process Log: ISSUE-193 - feat: sync profile skills to provider-native AI Skills for Knowledge chats
@@ -18,10 +18,10 @@ Tracks cross-phase execution notes, incidents, reusable fixes, and workflow lear
 
 - Create: completed
 - Research: completed
-- Plan: not_started
+- Plan: completed
 - Implement: completed_direct
-- Current phase: research
-- Next step: human review, then move to Ready for Plan and run core/20-plan
+- Current phase: plan
+- Next step: human review, then core/30-implement
 
 ## Phase Notes
 
@@ -33,27 +33,32 @@ Tracks cross-phase execution notes, incidents, reusable fixes, and workflow lear
 
 ### Research
 
-- Summary: Completed reconciliation research for provider-native profile skills in Knowledge chats, documenting current `social.skill`, `profiles-to-skills`, provider-sync, Knowledge generation, LLM gateway, legacy `react-by-knowledge`, and OpenRouter skill behavior.
+- Summary: Reworked reconciliation research after operator feedback invalidated the first plan. The corrected research documents that `react-by/openrouter` is the required Knowledge chat reply path for provider-native skill integration, while current OpenRouter behavior uses prompt-instruction skills only.
 - Outputs: Research artifact `thoughts/shared/research/singlepagestartup/ISSUE-193.md`.
-- Notes: Existing implementation notes in this process log were treated as historical context and verified against live code before writing the research artifact. Live code contains provider-native sync/gateway infrastructure, while current chat reply handlers apply selected skills as prompt instructions.
+- Notes: Existing implementation notes in this process log were treated as historical context and verified against live code before writing the research artifact. Live code contains provider-native sync/gateway infrastructure, while current `react-by/openrouter` applies selected skills as prompt instructions and the shared OpenRouter wrapper has no provider-skill request surface.
+- Notes: External documentation check confirmed that OpenRouter documents standard messages/tools/plugins/provider routing, but not OpenAI `skill_reference` or Anthropic `container.skills` mounting. The research artifact now records prompt/tool-based, hybrid provider-native, experimental passthrough, and custom shell options.
+- Notes: Clarified the planning rule: if generation stays on OpenRouter, skills are SPS-managed text/tool instructions. Native OpenAI/Anthropic Skills require a direct provider branch from `react-by/openrouter`.
 
 ### Plan
 
-- Summary:
-- Outputs:
-- Notes:
+- Summary: Created replacement implementation plan for OpenRouter message-attached social skill instructions. The plan supersedes the original provider-native ticket wording where it conflicts with the corrected research and operator clarification.
+- Outputs: Plan artifact `thoughts/shared/plans/singlepagestartup/ISSUE-193.md`.
+- Notes: The previous plan was invalidated and deleted because it scoped provider-native skill integration to legacy `react-by/knowledge` instead of required `react-by/openrouter`.
+- Notes: Do not reuse the deleted plan scope. Future implementation should use the corrected research artifact and the replacement plan.
+- Notes: Operator clarified during planning that OpenRouter skills must be SPS-managed text instructions attached to the beginning of the triggering user message, not `system` or `developer` messages. Reply profile description is the specialist/persona context and belongs in system context; `@knowledge` can still add RAG fragments.
+- Notes: Reviewer clarified that skill invocation in chat must use slash syntax (`/skill-slug`), only skills already linked to the replying profile can be invoked, current thread context must continue to be sent, and implementation verification must use the authenticated Browser session plus `npm run api:dev` backend logs.
 
 ### Implement
 
 - Summary: Implemented provider-native profile skills sync and Knowledge chat usage directly from the user-provided plan.
 - Outputs: Added RBAC profile skill provider-sync endpoint, SDK actions, Knowledge `providerSkills` propagation, OpenAI/Anthropic gateway payload support, and focused tests.
-- Notes: This implementation bypassed the normal `core/10-research` and `core/20-plan` issue phases because the user explicitly requested direct implementation after the create artifact was produced. Research reconciliation is now complete and GitHub Project status is `Research in Review`.
+- Notes: This implementation bypassed the normal `core/10-research` and `core/20-plan` issue phases because the user explicitly requested direct implementation after the create artifact was produced. The previous plan was later invalidated; planning must restart from the corrected `react-by/openrouter` research.
 
 ## Incident Log
 
 > Record only substantive incidents: debugging sessions, wrong assumptions, tool friction, helper failures, workflow gaps, or repeated recoveries.
 
-<!-- incident-count: 1 -->
+<!-- incident-count: 2 -->
 
 ### Incident 1 — GitHub network blocked by sandbox
 
@@ -65,6 +70,18 @@ Tracks cross-phase execution notes, incidents, reusable fixes, and workflow lear
 - **Preventive Action**: When `core-00-create` sees `error connecting to api.github.com`, rerun the unchanged helper workflow with network escalation rather than rewriting the GitHub sequence.
 - **References**: `.codex/skills/core-00-create/SKILL.md`; `.claude/helpers/create_issue_with_project.sh`.
 
+### Incident 2 — Plan scoped provider-native skills to legacy `react-by/knowledge`
+
+- **Phase**: Plan
+- **Occurrences**: 1
+- **Symptom**: Operator rejected the plan because it left provider-native skill integration out of `react-by/openrouter`, while current Knowledge chats use the OpenRouter reaction path.
+- **Root Cause**: The first research/plan pass treated the existing OpenRouter prompt-skill behavior as follow-up context instead of the required implementation surface.
+- **Fix**: Deleted the invalid plan artifact, rewrote the research artifact around `react-by/openrouter`, and moved the issue back through the research workflow.
+- **Preventive Action**: For social Knowledge chat work, treat the current dispatch/reply path (`react-by/openrouter`) as in scope unless the issue explicitly says legacy `react-by/knowledge` only.
+- **References**: `thoughts/shared/research/singlepagestartup/ISSUE-193.md`; deleted `thoughts/shared/plans/singlepagestartup/ISSUE-193.md`.
+
 ## Reusable Learnings
 
 - Use `.claude/helpers/create_issue_with_project.sh` for new SPS issues so GitHub issue creation, project assignment, and status transition fail fast in one helper-driven sequence.
+- For social Knowledge chat skill work, verify the live reply path before planning. Current UI/agent flows use `react-by/openrouter`; legacy `react-by/knowledge` findings are compatibility context, not sufficient implementation scope by themselves.
+- OpenRouter-compatible skills and provider-native Skills are different implementation classes. Use prompt/tool activation for broad OpenRouter model support; use a direct OpenAI/Anthropic branch when the requirement is native `SKILL.md` mounting.

--- a/thoughts/shared/prs/198_description.md
+++ b/thoughts/shared/prs/198_description.md
@@ -1,0 +1,24 @@
+## Summary
+
+Implements the corrected Issue #193 OpenRouter skill behavior: profile-linked `social.skill` records are invoked from chat with slash syntax and attached to the triggering user message as text instructions. The replying AI profile remains the system/persona context, and `@knowledge` continues to opt into profile-scoped RAG.
+
+## Changes
+
+- Changed `react-by/openrouter` so selected profile skills are expanded into a message-prefix instruction block on the latest user message instead of being injected as system messages.
+- Added a profile persona system block from the replying `social.profile` title/subtitle/description.
+- Kept Knowledge fragments in system grounding context only when `@knowledge` is requested, and kept `/learn` reserved.
+- Updated composer slash handling so `/` shows `/learn` plus active skills linked to the replying profile; `@` now remains scoped to `@knowledge`.
+- Updated `social.skill` chat display variants to show slash invocation (`/skill-slug`) where skills are used as chat commands.
+- Added BDD coverage for slash parsing, linked-profile scoping, message prefix placement, profile persona context, frontend picker behavior, and stale skill badge clearing.
+
+## Verification
+
+- [x] `npx nx run @sps/rbac:jest:test --testFile=libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/find-by-id/message/react-by-openrouter.spec.ts`
+- [x] `npx nx run @sps/rbac:jest:test --testFile=libs/modules/rbac/models/subject/frontend/component/src/lib/singlepage/social-module/profile/chat/message/list/default/ClientComponent.spec.tsx`
+- [x] `npx nx run @sps/rbac:tsc:build`
+- [x] Browser verification with `npm run api:dev`: opened an authenticated AI chat, confirmed `/` and `@knowledge /` show `/learn` plus linked `/youtube-description`, ArrowDown+Tab inserts `/youtube-description`, a single selected skill badge appears, and keyboard deletion clears it.
+
+## Notes
+
+- No migrations or schema changes.
+- The planned `npm run test:file -- <path>` helper currently fails before Jest because it calls `nx run` without a project; equivalent direct `npx nx run @sps/rbac:jest:test --testFile=...` commands were used.

--- a/thoughts/shared/research/singlepagestartup/ISSUE-193.md
+++ b/thoughts/shared/research/singlepagestartup/ISSUE-193.md
@@ -1,175 +1,253 @@
 ---
-date: 2026-06-13T23:22:05+0300
+date: 2026-06-14T16:46:38+0300
 researcher: flakecode
-git_commit: 93fcafc4c767f0cf7c72b703e851ab673c0bee5b
-branch: issue-195
+git_commit: 633776785d5375b31566363e2dd5cd0646ef4ba0
+branch: main
 repository: singlepagestartup
-topic: "Provider-native profile skills for Knowledge chats"
-tags: [research, codebase, social, rbac, knowledge, llm, skills]
+topic: "Provider-native profile skills in react-by/openrouter Knowledge chats"
+tags: [research, codebase, social, rbac, knowledge, llm, openrouter, skills]
 status: complete
-last_updated: 2026-06-13
+last_updated: 2026-06-15
 last_updated_by: flakecode
 ---
 
-# Research: Provider-Native Profile Skills For Knowledge Chats
+# Research: Provider-Native Profile Skills In `react-by/openrouter` Knowledge Chats
 
-**Date**: 2026-06-13T23:22:05+0300
+**Date**: 2026-06-14T16:46:38+0300
 **Researcher**: flakecode
-**Git Commit**: 93fcafc4c767f0cf7c72b703e851ab673c0bee5b
-**Branch**: issue-195
+**Git Commit**: 633776785d5375b31566363e2dd5cd0646ef4ba0
+**Branch**: main
 **Repository**: singlepagestartup
 
 ## Research Question
 
-Document how the current codebase represents `social.skill`, links skills to `social.profile`, syncs linked skills to provider-native OpenAI/Anthropic Skills, and passes skill references through Knowledge/LLM generation for `social.chat.variant="knowledge"` flows.
+Document how profile-linked `social.skill` records currently flow through the live social Knowledge chat stack, specifically the `react-by/openrouter` endpoint, and identify the existing code surfaces that already support provider-native OpenAI/Anthropic Skills.
 
-This is reconciliation research for issue 193: the process log records that implementation happened directly before the normal research and plan phases, so this document describes the live code as it exists now.
+This replaces the previous research/plan scope. The previous plan incorrectly treated provider-native Skills as a `react-by/knowledge` implementation detail and left `react-by/openrouter` as follow-up scope. The current product requirement is that Knowledge chats use `react-by/openrouter` as the primary reply path and that skill integration belongs in that path.
 
 ## Summary
 
-`social.skill` stores skill instructions in ordinary model fields and keeps provider sync state in generic `metadata` JSONB. The model has `title`, `description`, `status`, `defaultModelSlug`, `allowedModelSlugs`, `metadata`, `adminTitle`, and unique `slug` fields (`libs/modules/social/models/skill/backend/repository/database/src/lib/fields/singlepage.ts:4`). Profiles link to skills through `profiles-to-skills`, whose relation table stores `profileId`, `skillId`, `orderIndex`, and `variant` (`libs/modules/social/relations/profiles-to-skills/backend/repository/database/src/lib/schema.ts:10`).
+`social.skill` and `profiles-to-skills` already exist. A skill stores its user-facing instructions in model fields, especially `title`, `slug`, `description`, `status`, `defaultModelSlug`, `allowedModelSlugs`, and generic `metadata` JSONB. Profiles link to skills through `profiles-to-skills`, which stores `profileId`, `skillId`, `orderIndex`, and `variant`.
 
-RBAC exposes a profile-scoped provider sync endpoint at `POST /:id/social-module/profiles/:socialModuleProfileId/skills/provider-sync`, registered behind `RequestProfileSubjectIdOwner` (`libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/index.ts:504`). The handler loads skills linked through `profiles-to-skills`, rejects unlinked requested skill ids, skips archived skills, uploads a generated `SKILL.md` bundle to OpenAI and/or Anthropic, and writes returned references under `social.skill.metadata.providerSkills` (`libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/skill/provider-sync.ts:46`).
+The codebase already has provider-native infrastructure outside the OpenRouter reaction path:
 
-Provider bundle creation and metadata freshness are centralized in `provider-skills.ts`. A bundle is rendered from `slug`, `title`, and `description` as a markdown `SKILL.md` with frontmatter; its SHA-256 hash is stored as `contentHash` and used to detect stale provider refs (`libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/skill/provider-skills.ts:44`, `libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/skill/provider-skills.ts:113`).
+- RBAC exposes a profile-scoped provider sync endpoint that uploads linked skills to OpenAI and Anthropic and stores references in `social.skill.metadata.providerSkills`.
+- Knowledge generation can pass `providerSkills` to the local LLM gateway as `provider_skills`.
+- The local LLM gateway validates provider skills for OpenAI/Anthropic models and mounts them into OpenAI Responses API shell skills or Anthropic beta `container.skills`.
 
-The Knowledge generation client and local LLM gateway support provider-native skill references. `LlmChatClient.complete(...)` conditionally serializes `provider_skills` into the `/v1/chat/completions` request body (`libs/modules/knowledge/backend/app/api/src/lib/generation/index.ts:99`). The LLM gateway schema accepts `provider_skills`, validates that they match OpenAI or Anthropic models, and mounts them into provider-specific payloads (`apps/llm/singlepage/schemas.py:11`, `apps/llm/singlepage/service.py:56`, `apps/llm/singlepage/service.py:162`).
+The current `react-by/openrouter` endpoint is the active rich chat reply path for Knowledge chats. It accepts `skillIds`, detects `@knowledge`, supports `/learn`, includes thread context, supports manual/auto OpenRouter model selection, and supports reasoning controls. Its skill handling is prompt-based: linked selected skills are resolved as `promptSkills`, converted to a system prompt by `toSkillSystemPrompt(...)`, prepended to the OpenRouter message context, and written to metadata as `mode: "prompt-instruction"`.
 
-The current `react-by-knowledge` handler contains provider-native helper code, but its active `resolveKnowledgeSkills(...)` path returns selected skills as prompt instructions and returns `providerSkills: []` in both selected-skill and no-skill branches (`libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/find-by-id/message/react-by-knowledge.ts:727`). The file also contains `findProviderSkillsForProfile(...)`, which can validate fresh provider refs and convert them for Knowledge generation, but current references in the file show it is declared and not invoked (`libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/find-by-id/message/react-by-knowledge.ts:928`).
+The shared OpenRouter wrapper currently sends only OpenRouter chat completion fields such as `model`, `messages`, `max_tokens`, `reasoning`, `response_format`, and `temperature`. It has no `provider_skills`, `skills`, OpenAI `skill_reference`, or Anthropic `container.skills` request surface.
 
-The current OpenRouter reaction path, which the later chat controls work uses as the main chat reply path, has its own `@knowledge`, `/learn`, and `@skill` handling. It resolves selected or mentioned linked skills as prompt-instruction system messages and does not contain `providerSkills` handling (`libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/find-by-id/message/react-by-openrouter.ts:1573`, `libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/find-by-id/message/react-by-openrouter.ts:1853`).
+OpenRouter official documentation describes an OpenAI-compatible Chat Completions shape with `tools` and provider routing parameters, plus a Responses endpoint with `tools`, `plugins`, `provider`, and `reasoning`. The documentation checked for this research does not document OpenAI Agent Skills `skill_reference` mounting or Anthropic `container.skills` mounting through OpenRouter. That means the current OpenRouter path cannot be assumed to support provider-native Skills by simply forwarding existing gateway `provider_skills`.
+
+Decision clarification: when a request is generated through OpenRouter, skills should be treated as SPS-managed text/tool instructions. OpenRouter can receive a selected skill as extra system/developer context, or through a normal function/tool activation loop that returns the skill instructions. This is the only documented and reliable OpenRouter-compatible skill approach found in the checked sources. It should not be described as provider-native OpenAI/Anthropic Skills.
+
+After checking the current OpenRouter OpenAPI spec and external Agent Skills documentation, the documented OpenRouter-compatible implementation choices are:
+
+- Use OpenRouter prompt/tool-call skill activation: disclose a skill catalog, then inject or load selected skill instructions into context. This matches the Agent Skills client implementation guide, but it is not provider-native OpenAI/Anthropic Skills.
+- Use a hybrid `react-by/openrouter` endpoint that keeps the OpenRouter chat UX and model controls, but switches to direct OpenAI/Anthropic provider-native generation when selected skills require native mounting. This satisfies provider-native Skills using documented OpenAI/Anthropic APIs, but billing/metadata must explicitly reflect the non-OpenRouter generation path.
+- Treat OpenRouter provider-specific passthrough for Skills as experimental only. OpenRouter documents that some provider-specific parameters are forwarded, but its docs and OpenAPI schema checked here do not list `skills`, `skill_reference`, or Anthropic `container.skills`, and unsupported parameters can be ignored.
 
 ## Detailed Findings
 
 ### Social Skill Model And Profile Links
 
-- `social.skill` uses `metadata: jsonb` for arbitrary structured state, which is the storage location used for `providerSkills` references (`libs/modules/social/models/skill/backend/repository/database/src/lib/fields/singlepage.ts:22`).
-- The public skill SDK currently exposes only the `default` variant for `social.skill` (`libs/modules/social/models/skill/sdk/model/src/lib/index.ts:17`).
-- `profiles-to-skills` is the profile/skill link relation. It stores foreign keys to profile and skill rows with cascade delete, and includes `orderIndex` for ordered rendering/use (`libs/modules/social/relations/profiles-to-skills/backend/repository/database/src/lib/schema.ts:10`).
-- The admin-v2 skill form renders editable fields for title, slug, description, status, default model slug, class name, and variant (`libs/modules/social/models/skill/frontend/component/src/lib/singlepage/admin-v2/form/ClientComponent.tsx:30`). It also exposes a `Relations` tab for `profilesToSkills` when the parent supplies that relation component (`libs/modules/social/models/skill/frontend/component/src/lib/singlepage/admin-v2/form/ClientComponent.tsx:58`).
+- `social.skill` defines the core fields used by provider skill bundles: `title`, unique `slug`, `description`, `status`, `defaultModelSlug`, `allowedModelSlugs`, `metadata`, and `adminTitle` (`libs/modules/social/models/skill/backend/repository/database/src/lib/fields/singlepage.ts:4`).
+- `metadata` is JSONB and is the existing storage location for provider sync references (`libs/modules/social/models/skill/backend/repository/database/src/lib/fields/singlepage.ts:22`).
+- `profiles-to-skills` is the profile/skill link relation. It stores `profileId`, `skillId`, `orderIndex`, and `variant`, with cascade delete foreign keys to profile and skill rows (`libs/modules/social/relations/profiles-to-skills/backend/repository/database/src/lib/schema.ts:10`).
+- The admin-v2 skill form exposes skill fields and has a `Relations` tab when relation components are provided, including profile links (`libs/modules/social/models/skill/frontend/component/src/lib/singlepage/admin-v2/form/ClientComponent.tsx:58`).
 
-### Provider Sync Endpoint
+### Provider Sync Already Exists
 
-- RBAC imports the provider sync handler in the subject singlepage controller (`libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/index.ts:66`) and registers `POST /:id/social-module/profiles/:socialModuleProfileId/skills/provider-sync` (`libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/index.ts:504`).
-- The provider sync request body accepts `providers?: ("openai" | "anthropic")[]`, `skillIds?: string[]`, and `force?: boolean` (`libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/skill/provider-sync.ts:17`).
-- Omitted or empty `providers` defaults to both supported providers; invalid provider entries throw a validation error (`libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/skill/provider-skills.ts:81`).
-- The handler verifies the profile exists, loads linked skill ids through `profilesToSkills.find(...)`, targets either requested ids or all linked ids, and rejects requested ids that are not linked to the profile (`libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/skill/provider-sync.ts:56`).
-- Archived linked skills are reported in `skipped` and are not uploaded (`libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/skill/provider-sync.ts:78`).
-- For each non-archived target skill/provider pair, the handler reuses a fresh reference unless `force` is true; otherwise it uploads the bundle, builds an `IProviderSkillReference`, writes it into metadata, and updates the skill row (`libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/skill/provider-sync.ts:220`, `libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/skill/provider-sync.ts:251`).
+- The RBAC subject singlepage controller registers `POST /:id/social-module/profiles/:socialModuleProfileId/skills/provider-sync` behind the profile subject owner middleware (`libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/index.ts:504`).
+- The sync request accepts `providers?: ("openai" | "anthropic")[]`, `skillIds?: string[]`, and `force?: boolean` (`libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/skill/provider-sync.ts:17`).
+- The handler loads `profilesToSkills`, rejects requested skill ids that are not linked to the profile, skips archived skills, uploads provider bundles, and updates the skill `metadata` with provider refs (`libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/skill/provider-sync.ts:56`, `libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/skill/provider-sync.ts:78`, `libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/skill/provider-sync.ts:251`).
+- `buildProviderSkillBundle(...)` renders a minimal markdown `SKILL.md` from the skill slug/title/description and computes a SHA-256 `contentHash` (`libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/skill/provider-skills.ts:44`).
+- Stored provider references include `provider`, `providerSkillId`, optional `version`, `name`, `sourceSkillId`, `sourceSkillSlug`, `contentHash`, and `syncedAt` (`libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/skill/provider-skills.ts:17`).
+- Freshness validation checks the stored provider skill id, source skill id, and bundle hash (`libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/skill/provider-skills.ts:113`).
+- OpenAI sync posts a `files[]` markdown bundle to `https://api.openai.com/v1/skills` (`libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/skill/provider-skills.ts:197`).
+- Anthropic sync posts the bundle to `https://api.anthropic.com/v1/skills` with Anthropic version and beta headers (`libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/skill/provider-skills.ts:234`).
 
-### Provider Skill Bundle And Metadata
-
-- `buildProviderSkillBundle(...)` derives `title`, normalized `name`, stringified instructions, normalized provider description, rendered `SKILL.md`, and SHA-256 `contentHash` from a `social.skill` (`libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/skill/provider-skills.ts:44`).
-- The generated markdown uses YAML-like frontmatter fields `name` and `description`, followed by an H1 title and the skill instructions (`libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/skill/provider-skills.ts:53`).
-- Stored provider references contain `provider`, `providerSkillId`, optional `version`, `name`, `sourceSkillId`, `sourceSkillSlug`, `contentHash`, and `syncedAt` (`libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/skill/provider-skills.ts:17`).
-- Freshness requires a stored `providerSkillId`, a matching rendered bundle hash, and the same source skill id (`libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/skill/provider-skills.ts:113`).
-- `putProviderSkillReference(...)` preserves existing metadata and merges the new reference at `metadata.providerSkills[provider]` (`libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/skill/provider-skills.ts:144`).
-
-### Provider Upload Calls
-
-- OpenAI sync reads `OPEN_AI_API_KEY` from shared utils or falls back to `process.env.OPENAI_API_KEY`, appends a `${bundle.name}/SKILL.md` markdown blob as `files[]`, and posts to `https://api.openai.com/v1/skills` (`libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/skill/provider-skills.ts:197`).
-- Anthropic sync reads `ANTHROPIC_API_KEY`, appends the same `files[]` style payload, and posts to `https://api.anthropic.com/v1/skills` with `anthropic-version` and beta headers for code execution, skills, and files (`libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/skill/provider-skills.ts:234`).
-- Upload response parsing accepts provider skill ids from `id`, `skill_id`, `skill.id`, or `data.id`, and derives version from `version`, `latest_version`, `skill.version`, or `"latest"` (`libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/skill/provider-skills.ts:274`).
-
-### SDK Surface
-
-- The server SDK action posts JSON to `/api/rbac/subjects/:id/social-module/profiles/:socialModuleProfileId/skills/provider-sync` and exposes typed request/result shapes for providers, skill ids, force, synced results, skipped results, and references (`libs/modules/rbac/models/subject/sdk/server/src/lib/singlepage/social-module/profile/find-by-id/skill/provider-sync.ts:1`).
-- The client SDK wraps the server action in a React Query mutation, saturates headers, uses `clientHost`, reports errors through `sonner`, and logs successful mutations to `globalActionsStore` (`libs/modules/rbac/models/subject/sdk/client/src/lib/singlepage/social-module/profile/find-by-id/skill/provider-sync.ts:1`).
-- Both client and server singlepage SDK barrels export the provider sync props, result, and action names (`libs/modules/rbac/models/subject/sdk/client/src/lib/singlepage/index.ts:233`, `libs/modules/rbac/models/subject/sdk/server/src/lib/singlepage/index.ts:266`).
-
-### Knowledge Generation And Provider Skills
+### Knowledge Generation And Local LLM Gateway Support Provider Skills
 
 - `KnowledgeGenerationProps` and `KnowledgeChatCompletionProps` both accept `providerSkills?: IKnowledgeProviderSkillReference[]` (`libs/modules/knowledge/backend/app/api/src/lib/generation/index.ts:28`, `libs/modules/knowledge/backend/app/api/src/lib/generation/index.ts:49`).
-- `LlmChatClient.generate(...)` forwards `props.providerSkills` to `complete(...)` after building the grounded prompt (`libs/modules/knowledge/backend/app/api/src/lib/generation/index.ts:74`).
-- `LlmChatClient.complete(...)` serializes `provider_skills` only when the provider skill array is non-empty (`libs/modules/knowledge/backend/app/api/src/lib/generation/index.ts:99`).
-- `buildGroundedPrompt(...)` keeps selected prompt skills in prompt text under `Selected skills`, while provider-native skill refs are not inserted into the prompt (`libs/modules/knowledge/backend/app/api/src/lib/generation/index.ts:170`).
-- `KnowledgeService.generate(...)` accepts `providerSkills` and passes them to the generation client alongside query, contexts, persona, prompt skill instructions, and chat history (`libs/modules/knowledge/backend/app/api/src/lib/service.ts:154`).
+- `LlmChatClient.complete(...)` serializes non-empty `providerSkills` as `provider_skills` in the local gateway request (`libs/modules/knowledge/backend/app/api/src/lib/generation/index.ts:99`).
+- The local gateway schema defines `ProviderSkillReference` and `ChatCompletionRequest.provider_skills` (`apps/llm/singlepage/schemas.py:11`, `apps/llm/singlepage/schemas.py:26`).
+- `GatewayService.chat_completion(...)` filters/validates provider skills for the selected model and passes them to the provider adapter (`apps/llm/singlepage/service.py:56`).
+- `_provider_skills_for_model(...)` rejects provider skills for non-OpenAI/non-Anthropic providers and rejects refs whose stored provider does not match the selected model provider (`apps/llm/singlepage/service.py:162`).
+- OpenAI provider skills become `{ type: "skill_reference", skill_id, version? }` (`apps/llm/singlepage/providers.py:41`).
+- Anthropic provider skills become `{ type: "custom", skill_id, version? }` (`apps/llm/singlepage/providers.py:53`).
+- The OpenAI provider uses `responses.create(...)` and mounts skills under a hosted shell tool environment (`apps/llm/singlepage/providers.py:270`).
+- The Anthropic provider uses beta Messages with `container.skills` and Skills/code execution/files beta headers (`apps/llm/singlepage/providers.py:184`).
 
-### LLM Gateway Provider-Native Mounts
+### Legacy `react-by/knowledge` Has Provider-Skill Helper Code But Is Not The Current Main Path
 
-- The gateway request schema defines `ProviderSkillReference` and `ChatCompletionRequest.provider_skills` (`apps/llm/singlepage/schemas.py:11`).
-- `GatewayService.chat_completion(...)` resolves a chat model, filters/validates provider skills with `_provider_skills_for_model(...)`, and passes them to the selected provider's `chat(...)` call (`apps/llm/singlepage/service.py:56`).
-- `_provider_skills_for_model(...)` rejects provider skills for non-OpenAI/non-Anthropic models and rejects refs whose `provider` does not match the selected model provider (`apps/llm/singlepage/service.py:162`).
-- OpenAI skill refs are converted to `{ type: "skill_reference", skill_id, version? }` (`apps/llm/singlepage/providers.py:41`).
-- Anthropic skill refs are converted to `{ type: "custom", skill_id, version? }` (`apps/llm/singlepage/providers.py:53`).
-- When OpenAI provider skills are present, `OpenAIProvider` uses `client.responses.create(...)` and adds a shell tool with `environment.type = "container_auto"` and `environment.skills = [...]` (`apps/llm/singlepage/providers.py:270`).
-- When Anthropic provider skills are present, `AnthropicProvider` uses `client.beta.messages.create(...)`, sends betas including `skills-2025-10-02`, passes `container.skills`, and enables code execution (`apps/llm/singlepage/providers.py:184`).
+- The legacy Knowledge reaction route is registered at `POST /:id/social-module/profiles/:socialModuleProfileId/chats/:socialModuleChatId/messages/:socialModuleMessageId/react-by/knowledge` (`libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/index.ts:457`).
+- `react-by-knowledge.ts` contains `findProviderSkillsForProfile(...)`, which validates fresh provider refs and converts them to Knowledge provider-skill format (`libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/find-by-id/message/react-by-knowledge.ts:928`).
+- The active `resolveKnowledgeSkills(...)` path in that file returns selected skills as prompt instructions and returns `providerSkills: []` for selected-skill and no-skill branches (`libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/find-by-id/message/react-by-knowledge.ts:727`).
+- The current UI/agent direction after the OpenRouter chat controls work is to route Knowledge chats through `react-by/openrouter`, so the legacy endpoint is compatibility context rather than the primary implementation surface for this issue.
 
-### Legacy `react-by-knowledge` Skill Behavior
+### Current `react-by/openrouter` Skill Flow
 
-- The Knowledge reaction route remains registered at `POST /:id/social-module/profiles/:socialModuleProfileId/chats/:socialModuleChatId/messages/:socialModuleMessageId/react-by/knowledge` (`libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/index.ts:457`).
-- `answerFromKnowledge(...)` reads `data.skillIds`, detects `@knowledge`, strips control mentions for selected skills/knowledge, loads profile-linked knowledge document ids, reads thread chat history, resolves the selected Knowledge model, resolves skills, and calls `KnowledgeService.generate(...)` (`libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/find-by-id/message/react-by-knowledge.ts:627`).
-- `resolveKnowledgeSkills(...)` currently returns prompt skills when `requestedSkillIds` are present and returns `providerSkills: []`; with no requested skill ids it returns empty prompt and provider skill arrays (`libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/find-by-id/message/react-by-knowledge.ts:727`).
-- The same file contains `findProviderSkillsForProfile(...)`, which loads active profile skills, verifies OpenAI/Anthropic provider support, checks stale provider metadata, and converts references to Knowledge provider-skill format, but the current file references show it is not called by `resolveKnowledgeSkills(...)` (`libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/find-by-id/message/react-by-knowledge.ts:928`).
-- Applied skill metadata can serialize both prompt-instruction and provider-native modes, depending on the arrays passed into `toAppliedKnowledgeSkillMetadata(...)` (`libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/find-by-id/message/react-by-knowledge.ts:893`).
+- `IRequestData` for `react-by-openrouter` accepts `skillIds?: string[]` and `useKnowledgeSearch?: boolean` (`libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/find-by-id/message/react-by-openrouter.ts:92`).
+- `IResolvedOpenRouterKnowledgeContext` contains `promptSkills` and `systemMessages`, but no `providerSkills` field (`libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/find-by-id/message/react-by-openrouter.ts:113`).
+- The handler normalizes `data.skillIds`, detects `@knowledge`, detects mentioned skill slugs, strips control mentions, and then loads the reply profile (`libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/find-by-id/message/react-by-openrouter.ts:884`).
+- `/learn` is validated to require `@knowledge` before generation proceeds (`libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/find-by-id/message/react-by-openrouter.ts:908`, `libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/find-by-id/message/react-by-openrouter.ts:1563`).
+- `resolveOpenRouterKnowledgeContext(...)` loads prompt skills linked to the reply profile by ids and mentioned slugs, then runs Knowledge search only when `@knowledge` was requested (`libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/find-by-id/message/react-by-openrouter.ts:1573`).
+- `findPromptSkillsForProfile(...)` verifies selected skill ids are linked to the profile, filters archived skills, and returns active linked skill rows (`libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/find-by-id/message/react-by-openrouter.ts:1731`).
+- `toSkillSystemPrompt(...)` formats selected skills into a system prompt that includes `@slug`, optional title, and the skill description (`libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/find-by-id/message/react-by-openrouter.ts:1853`).
+- The generated OpenRouter context prepends the prompt skill and Knowledge system messages before calling `generateFinalOpenRouterReply(...)` (`libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/find-by-id/message/react-by-openrouter.ts:1319`).
+- Reply metadata records selected skills as `mode: "prompt-instruction"` under `metadata.knowledge.skills` (`libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/find-by-id/message/react-by-openrouter.ts:1417`).
 
-### Current OpenRouter Knowledge/Skill Path
+### Current OpenRouter Wrapper Surface
 
-- `react-by-openrouter` parses query params `model` and `reasoning`, with `reasoning` allowed values `auto`, `none`, `low`, `medium`, `high`, and `xhigh` (`libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/find-by-id/message/react-by-openrouter.ts:1510`).
-- During execution, the handler reads `data.skillIds`, detects `@knowledge`, detects mentioned skill slugs, and sanitizes the trigger query by removing control mentions when skills or knowledge are active (`libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/find-by-id/message/react-by-openrouter.ts:884`).
-- `resolveOpenRouterKnowledgeContext(...)` loads mentioned skill slugs, resolves selected prompt skills linked to the reply profile, resolves profile-linked document ids, runs Knowledge search only when knowledge was requested, and returns system messages for prompt skills and Knowledge fragments (`libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/find-by-id/message/react-by-openrouter.ts:1573`).
-- `findPromptSkillsForProfile(...)` accepts selected skill ids and mentioned skill slugs, verifies selected ids are linked to the profile, filters archived skills, and returns active linked skill rows (`libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/find-by-id/message/react-by-openrouter.ts:1731`).
-- `toSkillSystemPrompt(...)` formats selected skills as a system prompt containing each `@slug`, optional title, and `description` instructions (`libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/find-by-id/message/react-by-openrouter.ts:1853`).
-- OpenRouter reply metadata stores `useKnowledgeSearch`, `documentIds`, citations/sources, `requestedSkillIds`, prompt skill metadata, and selected OpenRouter model/reasoning values (`libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/find-by-id/message/react-by-openrouter.ts:1417`).
-- A repo search for `providerSkills` in `react-by-openrouter.ts` returns no matches, so current OpenRouter skill usage is prompt-instruction based rather than provider-native.
+- `IOpenRouterRequestMessage` is only `{ role, content }` (`libs/shared/third-parties/src/lib/open-router/index.ts:29`).
+- `requestCompletion(...)` posts to `/chat/completions` with `model`, `messages`, `stream`, `max_tokens`, optional `reasoning`, optional `response_format`, and optional `temperature` (`libs/shared/third-parties/src/lib/open-router/index.ts:231`).
+- `generate(...)` passes context/model/fallback/reasoning/format/temperature into `requestCompletion(...)`; it has no provider skills argument (`libs/shared/third-parties/src/lib/open-router/index.ts:547`).
+- The retry path after multimodal failures repeats the same request shape and also has no provider skills argument (`libs/shared/third-parties/src/lib/open-router/index.ts:586`).
+- `IOpenRouterModel.supported_parameters` includes standard OpenRouter parameters such as `"tools"`, `"reasoning"`, `"response_format"`, and `"web_search_options"`, but no `"skills"`, `"provider_skills"`, `"skill_reference"`, or `"container.skills"` parameter (`libs/shared/third-parties/src/lib/open-router/interface.ts:117`).
 
-### Tests
+### OpenRouter Documentation Checked
 
-- `provider-sync.spec.ts` covers fresh sync upload/storage, fresh metadata skip, stale hash detection, archived skill skip, and unlinked skill rejection (`libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/skill/provider-sync.spec.ts:98`).
-- `generation/index.spec.ts` covers that Knowledge generation includes provider-native skill references as `provider_skills` outside the prompt body (`libs/modules/knowledge/backend/app/api/src/lib/generation/index.spec.ts:87`).
+- OpenRouter Chat Completions is documented as an OpenAI-compatible shape with `models`, `route`, and `provider` OpenRouter-specific fields, plus standard fields such as `tools` and `tool_choice`: https://openrouter.ai/docs/api/reference/overview.
+- OpenRouter parameter docs list supported request parameters and note that OpenRouter may accept additional provider-specific parameters, but the documented common parameter set does not include Skills-specific fields: https://openrouter.ai/docs/api/reference/parameters.
+- OpenRouter Responses API docs show `tools`, `plugins`, `provider`, and `reasoning` fields for `/api/v1/responses`; the checked documentation has no `skills`, `skill_reference`, or Anthropic `container.skills` entries: https://openrouter.ai/docs/api/api-reference/responses/create-responses.
+- The codebase OpenRouter wrapper currently uses Chat Completions, not the OpenRouter Responses endpoint (`libs/shared/third-parties/src/lib/open-router/index.ts:240`).
+
+### Decision Note: OpenRouter Skills Are Text Or Tool Instructions
+
+For the next implementation plan, treat OpenRouter skill support as a prompt/tool feature:
+
+- `@skill` can select a linked active `social.skill`.
+- The selected skill can be injected into the OpenRouter request as explicit instructions in system/developer context.
+- Alternatively, OpenRouter `tools` can expose a local activation function that returns the selected skill's `SKILL.md`/description content when the model asks for it.
+- In both cases, the skill remains an SPS-managed instruction bundle. OpenRouter receives normal text messages or normal tool-call results.
+
+Do not plan an OpenRouter-only implementation that assumes native OpenAI `skill_reference` or Anthropic `container.skills` mounting. The checked OpenRouter docs and OpenAPI schema do not document those fields. A provider-native implementation must branch from the `react-by/openrouter` orchestration into the direct OpenAI/Anthropic gateway when the final model/provider supports native Skills.
+
+### External Implementation Options For Skills With OpenRouter
+
+The current OpenRouter docs and OpenAPI schema do not expose a first-class Agent Skills parameter. The practical implementation options are therefore different in how close they stay to provider-native Skills.
+
+#### Option A: Prompt catalog plus skill instruction injection through OpenRouter
+
+This is the most portable OpenRouter approach. The Agent Skills client implementation guide describes the generic pattern: discover `SKILL.md`, expose a catalog with `name` and `description`, and activate a skill by either letting the model read `SKILL.md` through a file-read tool or by returning the content from a dedicated activation tool. The same guide notes that when the model cannot read files directly, the client can inject skill content programmatically or provide an `activate_skill` tool.
+
+OpenRouter supports this because it supports ordinary messages and standard function/tool calling. OpenRouter's tool-calling docs describe a client-side loop: send tools, let the model request a tool call, execute the tool locally, then send tool results back. OpenRouter also documents the `tools` parameter using OpenAI's function calling request shape and transforms it for other providers.
+
+For SPS this maps to:
+
+- Keep `react-by/openrouter` as the generation path.
+- Convert linked `social.skill` records into a compact available-skills catalog.
+- When the user explicitly mentions `@skill`, inject the selected skill's instructions into the system/developer context or expose a local `activate_skill` tool.
+- Store metadata as prompt/tool-activated skill use, not provider-native skill use.
+
+This is compatible with OpenRouter, multi-provider, and current billing. It does not satisfy a strict requirement that OpenAI/Anthropic receive native Skills objects.
+
+#### Option B: OpenRouter function tool wrapper around skill activation
+
+This is a variation of Option A. Instead of injecting selected skill text immediately, register a function tool such as `activate_social_skill`. Its schema should constrain the name/id to linked active skills. When the model calls the tool, the server returns the selected `SKILL.md` body and optionally a resource listing.
+
+For SPS this maps to:
+
+- Use OpenRouter `tools` and a client-side tool loop.
+- Keep full skill bodies out of the initial context until the model needs them.
+- Preserve progressive disclosure more closely than always injecting full skill prompts.
+
+This is still not provider-native OpenAI/Anthropic Skills. It is a documented OpenRouter-compatible agent pattern.
+
+#### Option C: Direct provider-native branch inside `react-by/openrouter`
+
+This is the option that satisfies provider-native Skills using documented provider APIs. OpenAI documents Skills as versioned bundles with `SKILL.md`, uploaded through `/v1/skills`, and mounted in Responses API hosted shell through `tools[].environment.skills` with `skill_reference`. Anthropic documents Skills through beta Messages with `container.skills`, Skills beta headers, and code execution.
+
+For SPS this maps to:
+
+- Keep the public endpoint and UI flow as `react-by/openrouter`.
+- Resolve the selected final model/provider before generation.
+- If selected skills require provider-native mounting and the model provider is OpenAI or Anthropic, call the local LLM gateway/provider adapter that already supports `provider_skills`.
+- If the selected/manual/auto model is not OpenAI or Anthropic, fail clearly or require Auto to choose a compatible OpenAI/Anthropic model.
+- Record metadata showing the endpoint was `react-by/openrouter` but generation provider was direct OpenAI/Anthropic provider-native Skills, not OpenRouter prompt skills.
+
+This is the strongest match for the issue requirement. The tradeoff is that OpenRouter billing/routing cannot be treated as if the request was generated by OpenRouter; billing and metadata need an explicit separate path.
+
+#### Option D: OpenRouter provider-specific passthrough experiment
+
+OpenRouter docs say some provider-specific parameters are forwarded to providers, and the API overview says unsupported parameters may be ignored while the rest are forwarded. Provider routing also documents pass-through for certain Anthropic beta headers, but the supported Anthropic beta feature list checked here includes interleaved thinking and structured outputs, not Skills.
+
+The current OpenRouter OpenAPI schema includes OpenAI Responses-style tools, OpenRouter server tools, and an OpenRouter shell server tool, but a direct search of the schema found no `skill` field. The OpenRouter `openrouter:shell` schema has a managed container environment but does not document `environment.skills`.
+
+For SPS this means an implementation could experimentally try:
+
+- OpenAI-shaped Responses request with `tools[].environment.skills`.
+- Anthropic-shaped request with `container.skills` and Skills beta headers.
+- `provider.require_parameters=true` and provider restrictions to prevent accidental fallback.
+
+However, this should be treated as unverified and feature-flagged. It should not be the main plan unless a live API probe proves OpenRouter forwards the exact fields and headers without stripping or ignoring them.
+
+#### Option E: OpenRouter server shell without Skills
+
+OpenRouter's OpenAPI schema includes an `openrouter:shell` server tool with an OpenRouter-managed `container_auto` environment. This resembles the shell/container part of OpenAI Skills, but the checked schema does not expose mounted skills under that environment. It can execute shell commands, but it is not a documented Agent Skills mounting mechanism.
+
+For SPS this is useful only if a future plan decides to implement a custom skill runtime by writing generated skill files into an OpenRouter shell container and driving the model/tool loop manually. That would be a custom runtime, not provider-native Skills.
+
+### Test Coverage That Already Exists
+
+- `provider-sync.spec.ts` covers fresh sync upload/storage, stale hash detection, archived skill skip, and unlinked skill rejection (`libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/skill/provider-sync.spec.ts:98`).
+- `generation/index.spec.ts` covers that Knowledge generation includes provider-native skill references as `provider_skills` outside the prompt (`libs/modules/knowledge/backend/app/api/src/lib/generation/index.spec.ts:87`).
 - `apps/llm/tests/test_gateway.py` covers matching-provider dispatch, unsupported provider rejection, OpenAI Responses shell skill mounts, and Anthropic beta `container.skills` mounts (`apps/llm/tests/test_gateway.py:216`, `apps/llm/tests/test_gateway.py:375`, `apps/llm/tests/test_gateway.py:446`).
-- `react-by-knowledge.spec.ts` covers `/learn`, `@knowledge` RAG, no-hidden-RAG normal generation, thread history, no silent linked-skill application, selected prompt skills, and combining `@knowledge` with selected prompt skills (`libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/find-by-id/message/react-by-knowledge.spec.ts:311`, `libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/find-by-id/message/react-by-knowledge.spec.ts:698`, `libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/find-by-id/message/react-by-knowledge.spec.ts:745`).
+- `react-by-openrouter.spec.ts` currently covers OpenRouter thread context, reply validation, reasoning mapping, manual model selection, prompt skill resolution, and Knowledge search behavior (`libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/find-by-id/message/react-by-openrouter.spec.ts:196`, `libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/find-by-id/message/react-by-openrouter.spec.ts:582`, `libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/find-by-id/message/react-by-openrouter.spec.ts:607`, `libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/find-by-id/message/react-by-openrouter.spec.ts:652`, `libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/find-by-id/message/react-by-openrouter.spec.ts:711`).
 
 ## Code References
 
-- `libs/modules/social/models/skill/backend/repository/database/src/lib/fields/singlepage.ts:4` - `social.skill` field set, including `description`, `status`, `allowedModelSlugs`, and `metadata`.
-- `libs/modules/social/relations/profiles-to-skills/backend/repository/database/src/lib/schema.ts:10` - profile/skill link relation.
-- `libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/index.ts:504` - provider-sync route registration.
+- `libs/modules/social/models/skill/backend/repository/database/src/lib/fields/singlepage.ts:4` - `social.skill` fields used as source data for skill bundles.
+- `libs/modules/social/relations/profiles-to-skills/backend/repository/database/src/lib/schema.ts:10` - profile-to-skill link relation.
+- `libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/index.ts:504` - RBAC provider-sync route registration.
 - `libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/skill/provider-sync.ts:46` - provider sync handler entrypoint.
-- `libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/skill/provider-skills.ts:44` - provider bundle creation.
-- `libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/skill/provider-skills.ts:197` - OpenAI Skills upload.
-- `libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/skill/provider-skills.ts:234` - Anthropic Skills upload.
-- `libs/modules/rbac/models/subject/sdk/server/src/lib/singlepage/social-module/profile/find-by-id/skill/provider-sync.ts:1` - server SDK provider-sync action.
-- `libs/modules/rbac/models/subject/sdk/client/src/lib/singlepage/social-module/profile/find-by-id/skill/provider-sync.ts:1` - client SDK provider-sync mutation.
-- `libs/modules/knowledge/backend/app/api/src/lib/generation/index.ts:19` - Knowledge provider skill reference shape.
-- `libs/modules/knowledge/backend/app/api/src/lib/generation/index.ts:99` - conditional `provider_skills` gateway payload serialization.
-- `apps/llm/singlepage/schemas.py:11` - LLM gateway provider skill request schema.
-- `apps/llm/singlepage/service.py:162` - gateway validation for supported/matching provider skills.
-- `apps/llm/singlepage/providers.py:41` - OpenAI/Anthropic provider skill payload helpers.
-- `apps/llm/singlepage/providers.py:184` - Anthropic beta Messages `container.skills` branch.
-- `apps/llm/singlepage/providers.py:270` - OpenAI Responses API branch with shell environment skills.
-- `libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/find-by-id/message/react-by-knowledge.ts:727` - current legacy Knowledge skill resolution returns prompt skills and empty provider skill refs.
-- `libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/find-by-id/message/react-by-openrouter.ts:1573` - current OpenRouter knowledge/skill context resolver.
-- `libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/find-by-id/message/react-by-openrouter.ts:1853` - OpenRouter prompt skill system message builder.
+- `libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/skill/provider-skills.ts:44` - provider bundle rendering.
+- `libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/skill/provider-skills.ts:113` - provider reference freshness check.
+- `libs/modules/knowledge/backend/app/api/src/lib/generation/index.ts:99` - Knowledge gateway payload includes `provider_skills`.
+- `apps/llm/singlepage/service.py:162` - local gateway provider skill validation.
+- `apps/llm/singlepage/providers.py:184` - Anthropic beta `container.skills` branch.
+- `apps/llm/singlepage/providers.py:270` - OpenAI Responses shell skills branch.
+- `libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/find-by-id/message/react-by-knowledge.ts:928` - legacy provider-skill resolver helper.
+- `libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/find-by-id/message/react-by-openrouter.ts:92` - OpenRouter reaction request data includes `skillIds`.
+- `libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/find-by-id/message/react-by-openrouter.ts:113` - OpenRouter resolved context contains prompt skills, not provider skills.
+- `libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/find-by-id/message/react-by-openrouter.ts:1573` - OpenRouter Knowledge/skill context resolution.
+- `libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/find-by-id/message/react-by-openrouter.ts:1853` - prompt skill system prompt rendering.
+- `libs/shared/third-parties/src/lib/open-router/index.ts:231` - OpenRouter chat completion request body shape.
+- `libs/shared/third-parties/src/lib/open-router/index.ts:547` - OpenRouter generate API surface.
+- `libs/shared/third-parties/src/lib/open-router/interface.ts:117` - OpenRouter model supported parameter type list.
 
 ## Architecture Documentation
 
-The current implementation keeps provider-native sync state on the `social.skill` record rather than introducing a new table. `profiles-to-skills` remains the ownership/scope relation that determines which skills can be synced or selected for a replying profile.
+Profile ownership and skill scoping currently live in RBAC orchestration and Social relations. `profiles-to-skills` determines which skills a reply profile can use, while `social.skill.metadata.providerSkills` stores provider upload references without a schema migration.
 
-RBAC owns subject/profile-scoped orchestration. The provider-sync endpoint is mounted under the RBAC subject profile route and uses the same owner middleware pattern as the chat reaction endpoints. The sync handler itself loads profile-linked skill ids from the Social relation service before it touches provider APIs.
+The existing provider-native path is split across three layers:
 
-Provider sync and provider use are split. Sync uploads the generated `SKILL.md` and stores provider references in `social.skill.metadata.providerSkills`. Generation support is implemented lower in the Knowledge client and LLM gateway: when a non-empty provider skill reference array reaches `LlmChatClient.complete(...)`, it becomes `provider_skills` in the local gateway request, and the gateway maps it to OpenAI or Anthropic native request fields.
+1. RBAC provider sync uploads linked skills and stores provider refs.
+2. Knowledge generation accepts provider refs and forwards them to the local LLM gateway.
+3. The local LLM gateway maps refs into OpenAI/Anthropic native request fields.
 
-Knowledge chats currently have two related reply implementations. The legacy `react-by-knowledge` endpoint can call `KnowledgeService.generate(...)` and has interfaces for provider skill refs, but the active resolver currently supplies selected `@skill` behavior as prompt instructions. The current OpenRouter endpoint is the richer chat path for model/reasoning controls, `@knowledge`, `/learn`, and `@skill`; it also uses prompt-instruction skills and profile-scoped Knowledge fragments.
+The current OpenRouter path is separate. It builds an OpenRouter message context and passes it to `OpenRouter.generate(...)`. Selected skills enter that context as ordinary system text. OpenRouter billing is settled from the `IOpenRouterGenerationSuccess.billing` returned by the OpenRouter wrapper, and the assistant message metadata records the OpenRouter selected model and reasoning values.
 
-Knowledge itself remains the RAG engine. It accepts provider skills and prompt skill instructions as generation inputs, but profile/document scoping is still resolved by RBAC or Knowledge service callers before generation.
+Because the current OpenRouter wrapper has no provider-native skill field and the checked OpenRouter docs do not document OpenAI/Anthropic Skills mounting through OpenRouter, provider-native skill use in `react-by/openrouter` is not present in the current codebase. The current behavior is prompt instruction skill use.
 
 ## Historical Context
 
-- `thoughts/shared/tickets/singlepagestartup/ISSUE-193.md` created the provider-native Skills scope: reuse `social.skill` and `profiles-to-skills`, store references in `metadata.providerSkills`, add provider sync, extend the LLM gateway, and integrate with Knowledge chats.
-- `thoughts/shared/processes/singlepagestartup/ISSUE-193.md` records that implementation was done directly before normal research/plan workflow, and that this research is a reconciliation pass over live code.
-- `thoughts/shared/research/singlepagestartup/ISSUE-192.md` documented the predecessor state for profile-scoped Knowledge RAG in social chats: Knowledge had profile-scoped search/generation/indexing, while the social chat bridge was still being introduced.
-- `thoughts/shared/plans/singlepagestartup/ISSUE-192.md` planned `social.chat.variant="knowledge"`, `/learn`, RBAC Knowledge reaction, agent dispatch, and frontend command picker. Issue 193 builds on those profile-scoped Knowledge chat surfaces.
-- `thoughts/shared/processes/singlepagestartup/ISSUE-192.md` records completion of the baseline Knowledge/RAG social chat implementation and reusable learnings around `social.chat.variant` as the RAG routing switch.
+- `thoughts/shared/tickets/singlepagestartup/ISSUE-193.md` created the provider-native Skills scope and originally named `react-by/knowledge` in the implementation notes.
+- The current operator correction supersedes the earlier narrow endpoint note: provider-native skills must be researched and planned for `react-by/openrouter`, because that endpoint is now the primary Knowledge chat reply path.
+- `thoughts/shared/processes/singlepagestartup/ISSUE-193.md` records that implementation happened directly before normal research/plan workflow and that the first plan was later invalidated.
+- `thoughts/shared/research/singlepagestartup/ISSUE-192.md` documented the predecessor state for profile-scoped Knowledge RAG in social chats.
+- `thoughts/shared/plans/singlepagestartup/ISSUE-192.md` planned `social.chat.variant="knowledge"`, `/learn`, RBAC Knowledge reaction, agent dispatch, and frontend command picker.
 
 ## Related Research
 
-- `thoughts/shared/research/singlepagestartup/ISSUE-192.md` - Baseline profile-scoped Knowledge/RAG in social chats.
-- `thoughts/shared/plans/singlepagestartup/ISSUE-192.md` - Implementation plan for Knowledge chat variant, `/learn`, and RBAC reaction integration.
-- `thoughts/shared/processes/singlepagestartup/ISSUE-193.md` - Process log for this issue, including direct implementation history.
+- `thoughts/shared/research/singlepagestartup/ISSUE-192.md` - baseline profile-scoped Knowledge/RAG in social chats.
+- `thoughts/shared/processes/singlepagestartup/ISSUE-193.md` - process log for this issue, including the invalidated plan scope.
 
 ## Open Questions
 
-- The live provider-sync endpoint and LLM gateway support provider-native skill references, while current `react-by-knowledge` and `react-by-openrouter` selected-skill behavior uses prompt instructions. The codebase therefore contains both provider-native infrastructure and prompt-instruction chat behavior.
-- `findProviderSkillsForProfile(...)` exists in `react-by-knowledge.ts` and implements fresh provider-ref validation, but current live references show no call site in that file.
-- Current OpenRouter chat flow has no `providerSkills` references; OpenRouter selected skills are rendered into system prompts.
+- OpenRouter docs checked for this research do not document provider-native Skills fields. The codebase therefore has no verified OpenRouter-native request shape for OpenAI `skill_reference` or Anthropic `container.skills`.
+- If provider-native Skills are required while the chat entrypoint remains `react-by/openrouter`, implementation must decide how `react-by/openrouter` selects or routes OpenAI/Anthropic provider-native generation while preserving the existing model/reasoning controls, metadata, and billing semantics.
+- Auto model selection currently can produce any configured OpenRouter model candidate. Provider-native skills in the existing LLM gateway are limited to OpenAI and Anthropic providers, so auto-selection behavior with selected skills needs an explicit compatibility rule.


### PR DESCRIPTION
## Summary

Implements the corrected Issue #193 OpenRouter skill behavior: profile-linked `social.skill` records are invoked from chat with slash syntax and attached to the triggering user message as text instructions. The replying AI profile remains the system/persona context, and `@knowledge` continues to opt into profile-scoped RAG.

## Changes

- Changed `react-by/openrouter` so selected profile skills are expanded into a message-prefix instruction block on the latest user message instead of being injected as system messages.
- Added a profile persona system block from the replying `social.profile` title/subtitle/description.
- Kept Knowledge fragments in system grounding context only when `@knowledge` is requested, and kept `/learn` reserved.
- Updated composer slash handling so `/` shows `/learn` plus active skills linked to the replying profile; `@` now remains scoped to `@knowledge`.
- Updated `social.skill` chat display variants to show slash invocation (`/skill-slug`) where skills are used as chat commands.
- Added BDD coverage for slash parsing, linked-profile scoping, message prefix placement, profile persona context, frontend picker behavior, and stale skill badge clearing.

## Verification

- [x] `npx nx run @sps/rbac:jest:test --testFile=libs/modules/rbac/models/subject/backend/app/api/src/lib/controller/singlepage/social-module/profile/find-by-id/chat/find-by-id/message/react-by-openrouter.spec.ts`
- [x] `npx nx run @sps/rbac:jest:test --testFile=libs/modules/rbac/models/subject/frontend/component/src/lib/singlepage/social-module/profile/chat/message/list/default/ClientComponent.spec.tsx`
- [x] `npx nx run @sps/rbac:tsc:build`
- [x] Browser verification with `npm run api:dev`: opened an authenticated AI chat, confirmed `/` and `@knowledge /` show `/learn` plus linked `/youtube-description`, ArrowDown+Tab inserts `/youtube-description`, a single selected skill badge appears, and keyboard deletion clears it.

## Notes

- No migrations or schema changes.
- The planned `npm run test:file -- <path>` helper currently fails before Jest because it calls `nx run` without a project; equivalent direct `npx nx run @sps/rbac:jest:test --testFile=...` commands were used.
