### PR TITLE
Fix page-cache handler for string URL values

### DIFF
--- a/libs/modules/agent/models/agent/backend/app/api/src/lib/controller/singlepage/page/cache.spec.ts
+++ b/libs/modules/agent/models/agent/backend/app/api/src/lib/controller/singlepage/page/cache.spec.ts
@@ -1,0 +1,187 @@
+/**
+ * BDD Suite: agent host page-cache string URL handling.
+ *
+ * Given: the Host page service returns root and nested URL records as strings.
+ * When: the Agent page-cache handler processes every configured language.
+ * Then: it revalidates and fetches canonical localized paths without stopping after a page failure.
+ */
+
+const mockLoggerInfo = jest.fn();
+const mockLoggerError = jest.fn();
+
+jest.mock("@sps/shared-utils", () => ({
+  HOST_SERVICE_URL: "http://localhost:3000/",
+  RBAC_SECRET_KEY: "test-rbac-secret",
+}));
+
+jest.mock("@sps/shared-configuration", () => ({
+  internationalization: {
+    languages: [
+      {
+        title: "English",
+        code: "en",
+      },
+      {
+        title: "Russian",
+        code: "ru",
+      },
+    ],
+    defaultLanguage: {
+      title: "English",
+      code: "en",
+    },
+  },
+}));
+
+jest.mock("@sps/backend-utils", () => ({
+  getHttpErrorType: (error: Error) => ({
+    details: error,
+    message: error.message,
+    status: 500,
+  }),
+  logger: {
+    error: (...args: unknown[]) => mockLoggerError(...args),
+    info: (...args: unknown[]) => mockLoggerInfo(...args),
+  },
+}));
+
+import { Handler } from "./cache";
+
+const originalFetch = globalThis.fetch;
+
+function createContext() {
+  return {
+    json: jest.fn((payload: unknown) => payload),
+  } as any;
+}
+
+function createHandler() {
+  return new Handler({
+    hostModule: {
+      page: {
+        urls: jest.fn().mockResolvedValue([
+          {
+            url: "/",
+          },
+          {
+            url: "/gallery/item",
+          },
+        ]),
+      },
+    },
+  } as any);
+}
+
+describe("Given: Host page URLs use the documented string contract", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    jest.restoreAllMocks();
+  });
+
+  /**
+   * BDD Scenario: root and nested strings expand across languages.
+   *
+   * Given: root and nested URL strings plus English and Russian languages.
+   * When: the page-cache handler completes successfully.
+   * Then: every localized path is revalidated before it is fetched with exact separators.
+   */
+  it("Then: revalidates and fetches canonical default and localized paths", async () => {
+    const handler = createHandler();
+    const revalidatePage = jest
+      .spyOn(handler, "revalidatePage")
+      .mockResolvedValue(undefined);
+    const fetchPage = jest.fn().mockResolvedValue({
+      ok: true,
+    });
+    globalThis.fetch = fetchPage as any;
+    const context = createContext();
+    const expectedPaths = [
+      "http://localhost:3000/",
+      "http://localhost:3000/ru/",
+      "http://localhost:3000/gallery/item",
+      "http://localhost:3000/ru/gallery/item",
+    ];
+
+    const result = await handler.execute(context, jest.fn());
+
+    expect(revalidatePage.mock.calls.map(([path]) => path)).toEqual(
+      expectedPaths,
+    );
+    expect(fetchPage.mock.calls).toEqual(
+      expectedPaths.map((path) => [
+        path,
+        {
+          method: "GET",
+        },
+      ]),
+    );
+    for (const index of expectedPaths.keys()) {
+      expect(revalidatePage.mock.invocationCallOrder[index]).toBeLessThan(
+        fetchPage.mock.invocationCallOrder[index],
+      );
+    }
+    expect(context.json).toHaveBeenCalledWith({
+      data: {
+        ok: true,
+      },
+    });
+    expect(result).toEqual({
+      data: {
+        ok: true,
+      },
+    });
+  });
+
+  /**
+   * BDD Scenario: a page failure does not stop later URLs.
+   *
+   * Given: the first page fetch fails and later localized pages can succeed.
+   * When: the page-cache handler processes the complete URL list.
+   * Then: it logs the failed page and still reaches every later revalidation and fetch.
+   */
+  it("Then: continues after a failed page and completes later URLs", async () => {
+    const handler = createHandler();
+    const revalidatePage = jest
+      .spyOn(handler, "revalidatePage")
+      .mockResolvedValue(undefined);
+    const fetchPage = jest
+      .fn()
+      .mockResolvedValueOnce({
+        ok: false,
+      })
+      .mockResolvedValue({
+        ok: true,
+      });
+    globalThis.fetch = fetchPage as any;
+    const context = createContext();
+    const expectedPaths = [
+      "http://localhost:3000/",
+      "http://localhost:3000/ru/",
+      "http://localhost:3000/gallery/item",
+      "http://localhost:3000/ru/gallery/item",
+    ];
+
+    const result = await handler.execute(context, jest.fn());
+
+    expect(revalidatePage.mock.calls.map(([path]) => path)).toEqual(
+      expectedPaths,
+    );
+    expect(fetchPage.mock.calls.map(([path]) => path)).toEqual(expectedPaths);
+    expect(mockLoggerError).toHaveBeenCalledWith(
+      "http://localhost:3000/ - Failed to fetch page",
+      {
+        page: "http://localhost:3000/",
+        error: expect.any(Error),
+      },
+    );
+    expect(result).toEqual({
+      data: {
+        ok: true,
+      },
+    });
+  });
+});

--- a/libs/modules/agent/models/agent/backend/app/api/src/lib/controller/singlepage/page/cache.ts
+++ b/libs/modules/agent/models/agent/backend/app/api/src/lib/controller/singlepage/page/cache.ts
@@ -21,16 +21,20 @@ export class Handler {
       logger.info("Host module page cache started");
 
       const urls = await this.service.hostModule.page.urls();
+      const hostServiceUrl = HOST_SERVICE_URL.replace(/\/+$/, "");
 
       if (urls?.length) {
-        for (const [index, url] of urls.entries()) {
+        for (const url of urls) {
           for (const language of internationalization.languages) {
             const code =
               language.code === internationalization.defaultLanguage.code
                 ? ""
-                : language.code + "/";
+                : language.code;
+            const urlPath = url.url.replace(/^\/+|\/+$/g, "");
+            const localizedPath = [code, urlPath].filter(Boolean).join("/");
+            const rootSuffix = !urlPath && localizedPath ? "/" : "";
 
-            const path = HOST_SERVICE_URL + "/" + code + url.url.join("/");
+            const path = `${hostServiceUrl}/${localizedPath}${rootSuffix}`;
 
             try {
               await this.revalidatePage(path);

--- a/thoughts/shared/handoffs/singlepagestartup/ISSUE-218-progress.md
+++ b/thoughts/shared/handoffs/singlepagestartup/ISSUE-218-progress.md
@@ -3,7 +3,8 @@ issue_number: 218
 issue_title: "Fix page-cache handler for string URL values"
 start_date: 2026-07-28T14:16:31Z
 plan_file: thoughts/shared/plans/singlepagestartup/ISSUE-218.md
-status: in_progress
+status: complete
+completed_date: 2026-07-28T14:48:58Z
 ---
 
 # Implementation Progress: ISSUE-218 - Fix page-cache handler for string URL values
@@ -54,8 +55,8 @@ status: in_progress
 
 ### Pull Request
 
-- [ ] PR created: —
-- [ ] PR number: —
+- [x] PR created: https://github.com/singlepagestartup/singlepagestartup/pull/221
+- [x] PR number: 221
 
 ### Final Status
 
@@ -65,4 +66,4 @@ status: in_progress
 
 ---
 
-**Last updated**: 2026-07-28T14:44:54Z
+**Last updated**: 2026-07-28T14:48:58Z

--- a/thoughts/shared/handoffs/singlepagestartup/ISSUE-218-progress.md
+++ b/thoughts/shared/handoffs/singlepagestartup/ISSUE-218-progress.md
@@ -1,0 +1,68 @@
+---
+issue_number: 218
+issue_title: "Fix page-cache handler for string URL values"
+start_date: 2026-07-28T14:16:31Z
+plan_file: thoughts/shared/plans/singlepagestartup/ISSUE-218.md
+status: in_progress
+---
+
+# Implementation Progress: ISSUE-218 - Fix page-cache handler for string URL values
+
+**Started**: 2026-07-28
+**Plan**: `thoughts/shared/plans/singlepagestartup/ISSUE-218.md`
+
+## Phase Progress
+
+### Phase 1: Normalize Localized Page Paths
+
+- [x] Started: 2026-07-28T14:17:55Z
+- [x] Completed: 2026-07-28T14:44:54Z
+- [x] Automated verification: PASSED — focused Jest, Agent TypeScript, and Agent lint
+
+**Notes**: The handler now consumes `url.url` as a string and composes normalized default-language and Russian root/nested paths. Human verification was confirmed before commit/release.
+
+### Phase 2: Add Focused BDD Regression Coverage
+
+- [x] Started: 2026-07-28T14:18:34Z
+- [x] Completed: 2026-07-28T14:44:54Z
+- [x] Automated verification: PASSED — focused Jest (2 tests) and full Agent Jest (16 suites / 86 tests)
+
+**Notes**: Phase 1 and Phase 2 are verified together because the Phase 1 success criteria explicitly depend on the Phase 2 focused spec. The real Handler is exercised with root and nested string URL records, exact English/Russian paths, call ordering, and continuation after a failed page fetch. Human verification was confirmed before commit/release.
+
+### Phase 3: Verify the Live Page-Cache Endpoint
+
+- [x] Started: 2026-07-28T14:26:19Z
+- [x] Completed: 2026-07-28T14:44:54Z
+- [x] Automated verification: PASSED — `git diff --check` and all planned checks
+
+**Notes**: The authenticated local POST completed with HTTP 200 and `{"data":{"ok":true}}` after processing the full URL/language set. The original `url.url.join is not a function` failure did not recur. The Host terminal contains unrelated pre-existing Client Component serialization errors; they did not prevent the cache endpoint from completing. Human verification was confirmed before commit/release.
+
+## Incident Log
+
+> Read this section FIRST before starting any implementation work.
+> Parallel agents: check here for known pitfalls before debugging independently.
+
+<!-- incident-count: 0 -->
+
+## Summary
+
+### Changes Made
+
+- Normalized Host base URLs, language segments, and string page URLs in the Agent page-cache Handler.
+- Added focused BDD coverage for canonical localized paths, revalidate-before-fetch ordering, and continuation after a page failure.
+- Verified the production-equivalent authenticated local endpoint returns HTTP 200.
+
+### Pull Request
+
+- [ ] PR created: —
+- [ ] PR number: —
+
+### Final Status
+
+- [x] All phases completed
+- [x] All automated verification passed
+- [ ] Issue marked as Done
+
+---
+
+**Last updated**: 2026-07-28T14:44:54Z

--- a/thoughts/shared/plans/singlepagestartup/ISSUE-218.md
+++ b/thoughts/shared/plans/singlepagestartup/ISSUE-218.md
@@ -1,0 +1,288 @@
+---
+date: 2026-07-28T17:08:52+03:00
+issue_number: 218
+repository: singlepagestartup
+topic: "Fix page-cache handler for string URL values"
+status: in_review
+---
+
+# Fix Page-Cache Handler for String URL Values Implementation Plan
+
+## Overview
+
+Update the Agent page-cache handler to consume the Host service's
+`{ url: string }` contract, build canonical localized page paths, and preserve
+per-page failure isolation. Add focused BDD coverage for every path and
+continuation case required by issue #218.
+
+## Current State Analysis
+
+The Host page service declares and returns flattened `{ url: string }[]`
+records, including `"/"` for the root and leading-slash strings for nested
+pages
+(`libs/modules/host/models/page/backend/app/api/src/lib/service/singlepage/index.ts:11-13`,
+`libs/modules/host/models/page/backend/app/api/src/lib/service/singlepage/index.ts:180-198`,
+`libs/modules/host/models/page/backend/app/api/src/lib/service/singlepage/index.ts:225-238`).
+
+The Agent page-cache handler iterates those records for every configured
+language but calls `.join("/")` on each string while constructing the page
+path
+(`libs/modules/agent/models/agent/backend/app/api/src/lib/controller/singlepage/page/cache.ts:23-33`).
+This throws before the inner per-page error boundary, so revalidation and page
+fetching never begin. The existing inner boundary already logs downstream
+failures and continues to later language/URL iterations
+(`libs/modules/agent/models/agent/backend/app/api/src/lib/controller/singlepage/page/cache.ts:35-50`).
+
+No focused page-cache controller spec currently exists. Nearby Agent scheduled
+controller tests establish the repository's BDD header, mocked dependency,
+minimal context, and direct Handler invocation pattern
+(`libs/modules/agent/models/agent/backend/app/api/src/lib/controller/singlepage/ecommerce-module/order/check.spec.ts:1-73`).
+
+## Desired End State
+
+For every `{ url: string }` returned by the Host service, the handler produces
+one canonical absolute page URL for every configured language, passes the same
+URL to revalidation and page fetching, and continues processing after a
+per-page downstream failure.
+
+With the current Host base URL and language configuration, the required
+observable paths are:
+
+- root, default language: `http://localhost:3000/`
+- nested, default language: `http://localhost:3000/gallery/item`
+- root, non-default language: `http://localhost:3000/ru/`
+- nested, non-default language: `http://localhost:3000/ru/gallery/item`
+
+The local authenticated page-cache POST completes successfully and no longer
+emits `url.url.join is not a function`.
+
+### Key Discoveries
+
+- The string URL contract is already authoritative in the Host service; the
+  mismatch is isolated to the Agent consumer
+  (`libs/modules/host/models/page/backend/app/api/src/lib/service/singlepage/index.ts:11-13`,
+  `libs/modules/agent/models/agent/backend/app/api/src/lib/controller/singlepage/page/cache.ts:23-33`).
+- English is the default language and Russian is the non-default language, so
+  the handler must preserve the existing empty/default and `ru/` prefix
+  semantics
+  (`libs/shared/configuration/src/lib/internationalization/index.ts:1-15`).
+- Revalidation and page fetch calls already share the constructed absolute
+  path, and the inner catch already provides continuation semantics
+  (`libs/modules/agent/models/agent/backend/app/api/src/lib/controller/singlepage/page/cache.ts:35-50`,
+  `libs/modules/agent/models/agent/backend/app/api/src/lib/controller/singlepage/page/cache.ts:65-80`).
+- The project-qualified Agent Jest target is the reliable focused-test command;
+  the shared `npm run test:file` wrapper has a recorded Nx parsing failure
+  (`thoughts/shared/processes/singlepagestartup/ISSUE-183.md`).
+
+## What We're NOT Doing
+
+- Changing the Host page service, its `{ url: string }[]` contract, or its URL
+  generation behavior.
+- Changing route registration, authorization middleware, environment values,
+  or internationalization configuration.
+- Changing the seed flow's GET/POST mismatch; it is separate from the page-cache
+  string-contract acceptance criteria.
+- Changing the handler's downstream failure policy, logging contract, or
+  revalidate-then-fetch ordering.
+- Adding database schema changes, migrations, repository snapshots, or data
+  modifications.
+- Adding frontend or Browser UI controls for this scheduled backend endpoint.
+
+## Implementation Approach
+
+Treat each Host record's `.url` value as the documented string at the Agent
+boundary. Normalize the page-relative portion and optional language prefix
+while composing the existing Host service base URL so root and nested paths
+contain exactly one separator. Keep the current URL/language loops,
+revalidation call, page GET, and per-page error boundary intact.
+
+Add a colocated controller spec that drives the real Handler with mocked Host
+URL records, language configuration, revalidation/page responses, logger, and
+Hono context. Assert observable paths and continuation behavior rather than
+source-code structure.
+
+## Phase 1: Normalize Localized Page Paths
+
+### Overview
+
+Align the Agent page-cache consumer with the Host service's string URL contract
+without changing route, service, or failure-handling boundaries.
+
+### Changes Required
+
+#### 1. Agent page-cache handler
+
+**File**:
+`libs/modules/agent/models/agent/backend/app/api/src/lib/controller/singlepage/page/cache.ts`
+
+**Why**: This is the only production location that treats the Host URL string
+as an array and aborts before revalidation or fetching.
+
+**Changes**:
+
+- Consume `url.url` as a string.
+- Normalize the Host base URL, optional non-default language segment, and page
+  string so the four required root/nested/default/non-default paths contain
+  exactly one separator.
+- Preserve the current loop order, one revalidation plus one page fetch per
+  URL/language combination, and the existing inner catch that allows later
+  combinations to continue.
+- Preserve the successful `{ data: { ok: true } }` response and existing error
+  mapping outside the per-page boundary.
+
+### Success Criteria
+
+#### Automated Verification
+
+- [x] The focused page-cache BDD spec introduced in Phase 2 passes for the four
+      required localized path shapes.
+- [x] Agent TypeScript validation passes:
+      `npx nx run @sps/agent:tsc:build`.
+- [x] Agent linting passes:
+      `npx nx run @sps/agent:eslint:lint`.
+
+#### Manual Verification
+
+- [x] Root and nested Host URL strings no longer throw during path construction.
+- [x] Default-language paths omit the language segment; Russian paths contain
+      one `ru` segment.
+- [x] Revalidation still precedes the page GET for each combination.
+
+---
+
+## Phase 2: Add Focused BDD Regression Coverage
+
+### Overview
+
+Protect the string-contract fix and the existing continuation semantics with a
+dedicated controller-level unit spec.
+
+### Changes Required
+
+#### 1. Page-cache controller specification
+
+**File**:
+`libs/modules/agent/models/agent/backend/app/api/src/lib/controller/singlepage/page/cache.spec.ts`
+
+**Why**: No current test executes this Handler with `{ url: string }` records or
+asserts its localized page-cache paths.
+
+**Changes**:
+
+- Add the required top-level `BDD Suite` JSDoc and per-test `BDD Scenario`
+  JSDoc blocks with explicit Given/When/Then lines.
+- Mock `HOST_SERVICE_URL`, `RBAC_SECRET_KEY`, English/Russian
+  internationalization, backend logging/error mapping, the Host `urls()`
+  service, global page fetch behavior, and a minimal JSON response context.
+- Cover `"/"` and `"/gallery/item"` fixtures across default and non-default
+  languages.
+- Assert the exact revalidation and page-fetch paths for all four combinations,
+  including the root trailing slash and absence of doubled separators.
+- Simulate a failed page operation followed by a successful later URL and
+  assert that later revalidation/fetch work still executes and the handler
+  returns success.
+- Restore mocked global fetch state after each scenario so the spec is isolated.
+
+### Success Criteria
+
+#### Automated Verification
+
+- [x] Focused page-cache tests pass:
+      `npx nx run @sps/agent:jest:test --testFile=libs/modules/agent/models/agent/backend/app/api/src/lib/controller/singlepage/page/cache.spec.ts`.
+- [x] The full Agent unit target passes:
+      `npx nx run @sps/agent:jest:test`.
+- [x] Assertions demonstrate that every URL/language combination reaches
+      revalidation and page fetching.
+- [x] Assertions demonstrate that a failed page does not prevent a later page
+      from running.
+
+#### Manual Verification
+
+- [x] Test names and JSDoc describe behavior rather than implementation details.
+- [x] The spec uses the real Handler and observable calls, without reading or
+      matching source text.
+
+---
+
+## Phase 3: Verify the Live Page-Cache Endpoint
+
+### Overview
+
+Re-run the original production-equivalent local request and confirm the failure
+signature is absent from the live API path.
+
+### Changes Required
+
+No additional production file changes are expected in this phase. Verification
+uses the existing local API and Host processes.
+
+### Success Criteria
+
+#### Automated Verification
+
+- [x] `git diff --check` passes.
+- [x] Focused Jest, full Agent Jest, Agent TypeScript, and Agent lint commands
+      listed above complete successfully.
+
+#### Manual Verification
+
+- [x] Authenticated
+      `POST http://127.0.0.1:4000/api/agent/agents/host-module-page-cache`
+      returns HTTP 200 with `{ data: { ok: true } }`.
+- [x] The response and API logs contain no
+      `url.url.join is not a function` signature.
+- [x] Root, nested, default-language, and Russian page paths reach the existing
+      revalidation/page-fetch flow.
+- [x] A downstream page failure remains logged and isolated while later pages
+      continue.
+
+## Testing Strategy
+
+### Unit Tests
+
+- Exercise the Handler directly with `{ url: string }` fixtures.
+- Assert exact root/nested paths for English and Russian.
+- Assert revalidate-before-fetch ordering and one pair of operations per
+  URL/language combination.
+- Assert continuation after a failed page followed by a successful page.
+- Assert the successful handler response once all combinations have been
+  attempted.
+
+### Integration Tests
+
+- No new database-backed scenario is required because the defect is isolated to
+  controller path composition and downstream-call orchestration.
+- Use the existing running API/Host stack for the production-equivalent endpoint
+  check after unit verification.
+
+### Manual Testing Steps
+
+1. Start or confirm the API on port 4000 and Host on port 3000.
+2. Source the existing API environment without printing the RBAC secret.
+3. POST to `/api/agent/agents/host-module-page-cache` with
+   `X-RBAC-SECRET-KEY`.
+4. Confirm HTTP 200 and the success JSON payload.
+5. Inspect API/Host output for the absence of the original type error and for
+   continued processing if any individual page cannot be fetched.
+
+## Performance Considerations
+
+The handler remains `O(urls × languages)` and retains one revalidation plus one
+page GET per combination. Path normalization is local string processing and
+does not introduce additional network requests or data reads.
+
+## Migration Notes
+
+No schema, data, configuration, or migration work is required. Rollback is
+limited to reverting the Agent handler and its colocated regression spec.
+
+## References
+
+- Original ticket:
+  `thoughts/shared/tickets/singlepagestartup/ISSUE-218.md`
+- Approved research:
+  `thoughts/shared/research/singlepagestartup/ISSUE-218.md`
+- Process log:
+  `thoughts/shared/processes/singlepagestartup/ISSUE-218.md`
+- GitHub issue:
+  https://github.com/singlepagestartup/singlepagestartup/issues/218

--- a/thoughts/shared/processes/singlepagestartup/ISSUE-218.md
+++ b/thoughts/shared/processes/singlepagestartup/ISSUE-218.md
@@ -1,0 +1,71 @@
+---
+issue_number: 218
+issue_title: "Fix page-cache handler for string URL values"
+repository: singlepagestartup
+created_at: 2026-07-28T13:49:45Z
+last_updated: 2026-07-28T14:44:54Z
+status: active
+current_phase: implement
+---
+
+# Process Log: ISSUE-218 - Fix page-cache handler for string URL values
+
+## Purpose
+
+Tracks cross-phase execution notes, incidents, reusable fixes, and workflow learnings.
+
+## Phase Status
+
+- Create: completed
+- Research: completed
+- Plan: completed
+- Implement: in_progress
+- Current phase: implement
+- Next step: complete implementation and submit PR
+
+## Phase Notes
+
+### Create
+
+- Summary: Issue already existed in GitHub and was resolved into the local workflow namespace.
+- Outputs: `thoughts/shared/tickets/singlepagestartup/ISSUE-218.md`
+- Notes: GitHub issue contained production evidence, a concrete root-cause claim, reproduction steps, and acceptance criteria.
+
+### Research
+
+- Summary: Reproduced the local HTTP 500, verified the live `{ url: string }` response contract, and documented the route, execution order, languages, and test patterns.
+- Outputs: `thoughts/shared/research/singlepagestartup/ISSUE-218.md`
+- Notes: The in-app Browser showed the Host page running without console errors; the scheduled backend endpoint has no direct control on the inspected page, so the failure was invoked through the authenticated local API route.
+
+### Plan
+
+- Summary: Planned a handler-only string URL normalization change, a focused BDD controller spec for localized paths and failure continuation, and production-equivalent local verification.
+- Outputs: `thoughts/shared/plans/singlepagestartup/ISSUE-218.md`
+- Notes: Host service, route/auth, internationalization configuration, database state, and the separate seed GET/POST mismatch remain out of scope.
+
+### Implement
+
+- Summary: Updated the page-cache Handler to normalize string page URLs and added focused BDD regression coverage for localized paths, call ordering, and continuation after a page failure.
+- Outputs: `libs/modules/agent/models/agent/backend/app/api/src/lib/controller/singlepage/page/cache.ts`, `libs/modules/agent/models/agent/backend/app/api/src/lib/controller/singlepage/page/cache.spec.ts`, `thoughts/shared/handoffs/singlepagestartup/ISSUE-218-progress.md`
+- Notes: Focused Jest, full Agent Jest, Agent TypeScript, Agent lint, and `git diff --check` passed. The authenticated local endpoint returned HTTP 200 with `{ "data": { "ok": true } }`; the human manual-verification checkpoint was confirmed before commit/release.
+
+## Incident Log
+
+> Record only substantive incidents: debugging sessions, wrong assumptions, tool friction, helper failures, workflow gaps, or repeated recoveries.
+
+<!-- incident-count: 1 -->
+
+### Incident 1 — GitHub helper required explicit network escalation
+
+- **Phase**: Research
+- **Occurrences**: 1
+- **Symptom**: The initial status helper reported that it could not connect to `api.github.com`.
+- **Root Cause**: The sandbox blocked the helper's required GitHub network access.
+- **Fix**: Re-ran the same shared helper command with approved escalated network access.
+- **Preventive Action**: When a workflow helper reports the documented GitHub connectivity failure in a sandbox, repeat that exact helper with network escalation instead of replacing it with raw GitHub commands.
+- **References**: `.claude/helpers/get_issue_status.sh`, `.claude/references/repository-context-contract.md`
+
+## Reusable Learnings
+
+- Local SPS API reproduction requests run on port 4000 in this checkout and should source `apps/api/.env` without printing the RBAC secret.
+- Focused Agent Jest verification should use the project-qualified `@sps/agent:jest:test --testFile=...` target because the shared `npm run test:file` wrapper has known Nx argument parsing failures.

--- a/thoughts/shared/processes/singlepagestartup/ISSUE-218.md
+++ b/thoughts/shared/processes/singlepagestartup/ISSUE-218.md
@@ -3,9 +3,9 @@ issue_number: 218
 issue_title: "Fix page-cache handler for string URL values"
 repository: singlepagestartup
 created_at: 2026-07-28T13:49:45Z
-last_updated: 2026-07-28T14:44:54Z
+last_updated: 2026-07-28T14:48:58Z
 status: active
-current_phase: implement
+current_phase: complete
 ---
 
 # Process Log: ISSUE-218 - Fix page-cache handler for string URL values
@@ -19,9 +19,9 @@ Tracks cross-phase execution notes, incidents, reusable fixes, and workflow lear
 - Create: completed
 - Research: completed
 - Plan: completed
-- Implement: in_progress
-- Current phase: implement
-- Next step: complete implementation and submit PR
+- Implement: completed
+- Current phase: complete
+- Next step: code review / merge
 
 ## Phase Notes
 
@@ -45,8 +45,8 @@ Tracks cross-phase execution notes, incidents, reusable fixes, and workflow lear
 
 ### Implement
 
-- Summary: Updated the page-cache Handler to normalize string page URLs and added focused BDD regression coverage for localized paths, call ordering, and continuation after a page failure.
-- Outputs: `libs/modules/agent/models/agent/backend/app/api/src/lib/controller/singlepage/page/cache.ts`, `libs/modules/agent/models/agent/backend/app/api/src/lib/controller/singlepage/page/cache.spec.ts`, `thoughts/shared/handoffs/singlepagestartup/ISSUE-218-progress.md`
+- Summary: Updated the page-cache Handler to normalize string page URLs, added focused BDD regression coverage for localized paths, call ordering, and continuation after a page failure, and opened PR #221.
+- Outputs: `libs/modules/agent/models/agent/backend/app/api/src/lib/controller/singlepage/page/cache.ts`, `libs/modules/agent/models/agent/backend/app/api/src/lib/controller/singlepage/page/cache.spec.ts`, `thoughts/shared/handoffs/singlepagestartup/ISSUE-218-progress.md`, `thoughts/shared/prs/221_description.md`, https://github.com/singlepagestartup/singlepagestartup/pull/221
 - Notes: Focused Jest, full Agent Jest, Agent TypeScript, Agent lint, and `git diff --check` passed. The authenticated local endpoint returned HTTP 200 with `{ "data": { "ok": true } }`; the human manual-verification checkpoint was confirmed before commit/release.
 
 ## Incident Log

--- a/thoughts/shared/prs/221_description.md
+++ b/thoughts/shared/prs/221_description.md
@@ -1,0 +1,30 @@
+# Summary
+
+Fix the Agent page-cache failure from issue #218 by consuming the Host page service's documented `{ url: string }` values and composing canonical localized page URLs.
+
+The cache endpoint now reaches revalidation and page fetching for root and nested pages in every configured language instead of throwing `url.url.join is not a function` before downstream work begins.
+
+Closes #218.
+
+## Changes
+
+- Normalize the Host service base URL, optional non-default language segment, and string page path with exactly one separator.
+- Preserve the existing URL/language iteration order, revalidate-before-fetch behavior, successful response, and per-page failure isolation.
+- Add focused BDD Handler coverage for root and nested string URLs across English and Russian.
+- Verify exact localized paths and continuation after an individual page fetch fails.
+- Add the canonical ticket, research, plan, process, and implementation-progress artifacts for issue #218.
+
+## Verification
+
+- [x] `npx nx run @sps/agent:jest:test --testFile=libs/modules/agent/models/agent/backend/app/api/src/lib/controller/singlepage/page/cache.spec.ts` (2/2).
+- [x] `npx nx run @sps/agent:jest:test` (16 suites / 86 tests).
+- [x] `npx nx run @sps/agent:tsc:build`.
+- [x] `npx nx run @sps/agent:eslint:lint`.
+- [x] Prettier and `git diff --check`.
+- [x] Authenticated local `POST /api/agent/agents/host-module-page-cache` returned HTTP 200 with `{ "data": { "ok": true } }`.
+- [x] The production-equivalent local run completed without `url.url.join is not a function`.
+
+## Notes
+
+- No schema, migration, configuration, or data changes are required.
+- Downstream page failures remain logged and isolated so later URL/language combinations continue.

--- a/thoughts/shared/research/singlepagestartup/ISSUE-218.md
+++ b/thoughts/shared/research/singlepagestartup/ISSUE-218.md
@@ -1,0 +1,214 @@
+---
+date: 2026-07-28T16:56:36+03:00
+researcher: flakecode
+git_commit: 592f6160bf05d57a0bb5b1b6751442c755906cb4
+branch: main
+repository: singlepagestartup
+topic: "Fix page-cache handler for string URL values"
+tags: [research, agent, host, page-cache, url]
+status: complete
+last_updated: 2026-07-28
+last_updated_by: flakecode
+---
+
+# Research: Fix page-cache handler for string URL values
+
+**Date**: 2026-07-28T16:56:36+03:00
+**Researcher**: flakecode
+**Git Commit**: 592f6160bf05d57a0bb5b1b6751442c755906cb4
+**Branch**: main
+**Repository**: singlepagestartup
+
+## Research Question
+
+Can issue #218 be reproduced against the locally running SPS stack, and what
+current route, data contract, execution order, language configuration, and test
+patterns govern the failing page-cache handler?
+
+## Summary
+
+The issue reproduces against the locally running API without code changes.
+An authenticated `POST` to
+`/api/agent/agents/host-module-page-cache` returns HTTP 500 with
+`url.url.join is not a function`. A separate read from
+`GET /api/host/pages/urls` returned 60 records whose `.url` values were all
+JSON strings, including the root record `{ "url": "/" }`.
+
+The Host page service declares `urls: { url: string }[]`, constructs normalized
+string values, and flattens them before returning. The Agent handler calls
+`.join("/")` on each returned string while constructing `path`. That expression
+is evaluated before the inner `try` containing `revalidatePage` and the page
+`fetch`, so neither downstream operation is reached for the first URL.
+
+The in-app Browser confirmed that the running Host page at
+`http://localhost:3000/en` renders normally and has no console errors. No direct
+UI control for this scheduled Agent endpoint exists in the inspected Host page
+or the located admin settings flow, so the failing backend code path was invoked
+directly against the local API.
+
+## Detailed Findings
+
+### Local reproduction
+
+The local processes were listening on Host port 3000 and API port 4000. The
+request body is not used. Authentication is supplied from the existing local
+API environment without printing its value:
+
+```bash
+bash -lc '
+  set -a
+  source apps/api/.env
+  set +a
+  curl -sS -i -X POST \
+    -H "X-RBAC-SECRET-KEY: $RBAC_SECRET_KEY" \
+    http://127.0.0.1:4000/api/agent/agents/host-module-page-cache
+'
+```
+
+Observed response:
+
+```text
+HTTP/1.1 500 Internal Server Error
+Content-Type: application/json
+
+"error":"Internal server error: url.url.join is not a function.
+(In 'url.url.join(\"/\")', 'url.url.join' is undefined)"
+```
+
+The returned stack points to
+`libs/modules/agent/models/agent/backend/app/api/src/lib/controller/singlepage/page/cache.ts:61`,
+where the original error is converted to `HTTPException`.
+
+A read-only request to the Host URL endpoint produced this compact contract
+check:
+
+```json
+{
+  "count": 60,
+  "first": {
+    "url": "/rbac/subject/authentication/email-and-password/registration"
+  },
+  "root": {
+    "url": "/"
+  },
+  "value_types": ["string"]
+}
+```
+
+### Route and authorization chain
+
+- The root API mounts the Agent module at `/api/agent` after the authorization
+  middleware (`apps/api/app.ts:171-180`).
+- The Agent module mounts the agent model app at `/agents`
+  (`libs/modules/agent/backend/app/api/src/lib/apps.ts:19-23`).
+- The model controller binds `POST /host-module-page-cache`
+  (`libs/modules/agent/models/agent/backend/app/api/src/lib/controller/singlepage/index.ts:80-83`).
+- The resulting local route is
+  `POST /api/agent/agents/host-module-page-cache`.
+- Authorization reads `X-RBAC-SECRET-KEY` or the corresponding cookie and
+  accepts a key matching server configuration
+  (`libs/middlewares/src/lib/is-authorized/index.ts:39-60`).
+- The handler also verifies that the server-side `RBAC_SECRET_KEY` exists before
+  reading URLs
+  (`libs/modules/agent/models/agent/backend/app/api/src/lib/controller/singlepage/page/cache.ts:15-23`).
+
+### Host page URL contract
+
+- `EntityWithUrls` declares `urls: { url: string }[]`
+  (`libs/modules/host/models/page/backend/app/api/src/lib/service/singlepage/index.ts:11-13`).
+- A root page returns `{ url: "/" }`
+  (`libs/modules/host/models/page/backend/app/api/src/lib/service/singlepage/index.ts:180-182`).
+- Non-root paths are constructed from segment arrays and converted to strings
+  with a normalized leading slash
+  (`libs/modules/host/models/page/backend/app/api/src/lib/service/singlepage/index.ts:184-198`).
+- `urls()` gathers each page's records and returns one flattened array
+  (`libs/modules/host/models/page/backend/app/api/src/lib/service/singlepage/index.ts:225-238`).
+- The public Host controller returns that array under `data.urls`
+  (`libs/modules/host/models/page/backend/app/api/src/lib/controller/singlepage/urls/index.ts:13-19`).
+
+### Agent handler execution order
+
+1. The handler loads the flattened Host URL records
+   (`libs/modules/agent/models/agent/backend/app/api/src/lib/controller/singlepage/page/cache.ts:21-23`).
+2. It loops over each record and each configured language
+   (`libs/modules/agent/models/agent/backend/app/api/src/lib/controller/singlepage/page/cache.ts:25-27`).
+3. It calculates an empty prefix for the default language and `<code>/` for
+   other languages
+   (`libs/modules/agent/models/agent/backend/app/api/src/lib/controller/singlepage/page/cache.ts:28-31`).
+4. It evaluates `url.url.join("/")` while assigning `path`
+   (`libs/modules/agent/models/agent/backend/app/api/src/lib/controller/singlepage/page/cache.ts:33`).
+5. Because `url.url` is a string, the assignment throws before execution enters
+   the per-page `try` at line 35. `revalidatePage` at line 36 and the page
+   `fetch` at lines 38-40 are therefore not reached.
+6. The outer catch maps the error and throws `HTTPException`
+   (`libs/modules/agent/models/agent/backend/app/api/src/lib/controller/singlepage/page/cache.ts:58-61`).
+
+### Language configuration
+
+The current internationalization configuration contains English (`en`) and
+Russian (`ru`), with English as the first/default language
+(`libs/shared/configuration/src/lib/internationalization/index.ts:1-13`).
+The handler's current prefix calculation therefore produces `""` for English
+and `"ru/"` for Russian before it reaches the failing expression.
+
+### Existing test patterns
+
+- No test file currently references `host-module-page-cache`,
+  `HostModulePageCache`, or `page/cache`.
+- Nearby Agent scheduled-controller tests use a top-level BDD JSDoc, mock
+  `@sps/shared-utils` and `@sps/backend-utils`, create a minimal Hono-like
+  context, instantiate the Handler with a mocked service, and assert observable
+  service calls
+  (`libs/modules/agent/models/agent/backend/app/api/src/lib/controller/singlepage/ecommerce-module/order/check.spec.ts:1-43`,
+  `libs/modules/agent/models/agent/backend/app/api/src/lib/controller/singlepage/ecommerce-module/order/check.spec.ts:51-73`).
+- The Agent Nx project exposes `jest:test`, `jest:integration`, `tsc:build`, and
+  `eslint:lint` targets (`libs/modules/agent/project.json:8-13`).
+- The root package provides a focused test-file command and scoped unit and
+  integration lanes (`package.json:26-30`).
+
+### Existing non-UI invocation
+
+The API seed flow contains a delayed fetch to the same page-cache URL with the
+RBAC header (`apps/api/src/db/seed.ts:419-428`). That fetch does not specify a
+method, while the controller registers the route as POST.
+
+## Code References
+
+- `apps/api/app.ts:171-180` - authorization middleware and Agent module mount.
+- `libs/modules/agent/backend/app/api/src/lib/apps.ts:19-23` - `/agents` mount.
+- `libs/modules/agent/models/agent/backend/app/api/src/lib/controller/singlepage/index.ts:80-83` - page-cache POST route.
+- `libs/modules/agent/models/agent/backend/app/api/src/lib/controller/singlepage/page/cache.ts:15-61` - failing handler execution.
+- `libs/modules/host/models/page/backend/app/api/src/lib/service/singlepage/index.ts:11-13` - URL record type.
+- `libs/modules/host/models/page/backend/app/api/src/lib/service/singlepage/index.ts:180-198` - root and nested string construction.
+- `libs/modules/host/models/page/backend/app/api/src/lib/service/singlepage/index.ts:225-238` - flattened URL array.
+- `libs/shared/configuration/src/lib/internationalization/index.ts:1-13` - language configuration.
+- `libs/middlewares/src/lib/is-authorized/index.ts:39-60` - secret-key authorization.
+- `libs/modules/agent/models/agent/backend/app/api/src/lib/controller/singlepage/ecommerce-module/order/check.spec.ts:1-73` - adjacent BDD controller-test pattern.
+- `apps/api/src/db/seed.ts:419-428` - delayed seed fetch to the page-cache URL.
+
+## Architecture Documentation
+
+The root README describes backend layering as Repository → Service → Controller
+→ App. This issue crosses the Host page service contract and the Agent
+controller handler. The Host model README describes pages as routable site
+containers, while the Agent model README describes agents as scheduled
+automation units. The failing endpoint is consequently an Agent automation
+controller consuming the Host page service's routable URL records.
+
+## Historical Context (from thoughts/)
+
+No earlier process, research, plan, or ticket artifact about Agent page-cache
+URL handling was present. The local ticket snapshot for this issue is
+`thoughts/shared/tickets/singlepagestartup/ISSUE-218.md` and records the
+production signature, reproduction outline, and acceptance criteria from
+GitHub.
+
+## Related Research
+
+No related research document was found in `thoughts/shared/research/singlepagestartup/`.
+
+## Open Questions
+
+- The current seed fetch defaults to GET, while the registered page-cache route
+  is POST. Whether this invocation-method mismatch belongs to issue #218 remains
+  a scope question for planning.

--- a/thoughts/shared/tickets/singlepagestartup/ISSUE-218.md
+++ b/thoughts/shared/tickets/singlepagestartup/ISSUE-218.md
@@ -1,0 +1,82 @@
+---
+issue_number: 218
+repository: singlepagestartup
+status: Research Needed
+created_at: 2026-07-27T21:26:37Z
+url: https://github.com/singlepagestartup/singlepagestartup/issues/218
+---
+
+# Issue #218: Fix page-cache handler for string URL values
+
+## Problem to solve
+
+The Agent page-cache endpoint fails before it can revalidate or fetch pages.
+The Host page service returns URL records as `{ url: string }`, but the Agent
+handler calls `.join("/")` on that string.
+
+Observed production signature:
+
+```text
+TypeError: url.url.join is not a function
+  at .../agent/.../controller/singlepage/page/cache.ts:61:17
+  at new HTTPException (.../hono/dist/http-exception.js:6:5)
+```
+
+`POST /api/agent/agents/host-module-page-cache` returns an internal error and
+page revalidation/fetching never starts. Expected behavior is to normalize every
+Host page URL as a string and revalidate/fetch it for every configured language.
+
+## Key details
+
+- Type: bug
+- Priority: medium
+- Size: small
+- Affected production service: `api_api`
+- Production image: `singlepagestartup/didigallery:0.0.221`
+- Production window: 2026-07-26T21:08Z to 2026-07-27T21:08Z
+- Top-level error records: 656
+- Matching signature lines: 704
+- First seen: 2026-07-27T10:31:02Z
+- Last seen: 2026-07-27T21:07:01Z
+
+## Reproduction
+
+1. Make `hostModule.page.urls()` return its documented value, for example
+   `[{ url: "/" }, { url: "/gallery/item" }]`.
+2. Execute the Agent host-module page-cache handler.
+3. The first iteration calls `.join` on the string and throws before
+   `revalidatePage` or `fetch`.
+
+## Implementation notes
+
+- The faulty call is reported at
+  `libs/modules/agent/models/agent/backend/app/api/src/lib/controller/singlepage/page/cache.ts`.
+- The string service contract and construction are in
+  `libs/modules/host/models/page/backend/app/api/src/lib/service/singlepage/index.ts`.
+- The issue records that upstream commit
+  `082c8287ab839e6fe7bfd5c97e1e38a56b4aff66` contains the same call.
+- This is a framework defect in `singlepagestartup/singlepagestartup`.
+
+## Acceptance criteria
+
+- [ ] Root and nested string URLs no longer throw.
+- [ ] Default and non-default language paths contain the intended single slash separators.
+- [ ] Every returned URL reaches revalidation and page fetch.
+- [ ] Per-page failures remain isolated and do not stop later URLs.
+- [ ] BDD tests cover `/`, a nested path, multiple languages, and a failed page followed by a successful page.
+- [ ] A production-equivalent run emits no `url.url.join is not a function` errors.
+
+## Test plan
+
+- Add a focused BDD controller/service test with `{ url: string }` fixtures.
+- Assert exact revalidation/fetch paths for root, nested, and localized URLs.
+- Assert later URLs still run when one fetch fails.
+- Run the affected Agent backend test target and TypeScript check.
+
+## References
+
+- https://github.com/singlepagestartup/singlepagestartup/issues/218
+
+## Comments
+
+No comments were present when the ticket snapshot was created.


### PR DESCRIPTION
# Summary

Fix the Agent page-cache failure from issue #218 by consuming the Host page service's documented `{ url: string }` values and composing canonical localized page URLs.

The cache endpoint now reaches revalidation and page fetching for root and nested pages in every configured language instead of throwing `url.url.join is not a function` before downstream work begins.

Closes #218.

## Changes

- Normalize the Host service base URL, optional non-default language segment, and string page path with exactly one separator.
- Preserve the existing URL/language iteration order, revalidate-before-fetch behavior, successful response, and per-page failure isolation.
- Add focused BDD Handler coverage for root and nested string URLs across English and Russian.
- Verify exact localized paths and continuation after an individual page fetch fails.
- Add the canonical ticket, research, plan, process, and implementation-progress artifacts for issue #218.

## Verification

- [x] `npx nx run @sps/agent:jest:test --testFile=libs/modules/agent/models/agent/backend/app/api/src/lib/controller/singlepage/page/cache.spec.ts` (2/2).
- [x] `npx nx run @sps/agent:jest:test` (16 suites / 86 tests).
- [x] `npx nx run @sps/agent:tsc:build`.
- [x] `npx nx run @sps/agent:eslint:lint`.
- [x] Prettier and `git diff --check`.
- [x] Authenticated local `POST /api/agent/agents/host-module-page-cache` returned HTTP 200 with `{ "data": { "ok": true } }`.
- [x] The production-equivalent local run completed without `url.url.join is not a function`.

## Notes

- No schema, migration, configuration, or data changes are required.
- Downstream page failures remain logged and isolated so later URL/language combinations continue.
