### PR TITLE
Coerce and validate ISO-8601 date strings for content create/update operations

### DIFF
--- a/apps/mcp/lib/content-management/operations.spec.ts
+++ b/apps/mcp/lib/content-management/operations.spec.ts
@@ -9,11 +9,13 @@ import { z } from "zod";
 import {
   applyDeleteContentModelRecord,
   createContentModelRecord,
+  createContentRelationRecord,
   describeContentEntities,
   describeContentModel,
   findContentModelRecords,
   previewDeleteContentModelRecord,
   updateContentModelRecord,
+  updateContentRelationRecord,
   updateLocalizedContentField,
 } from "./operations";
 import { IContentEntityDescriptor } from "./types";
@@ -84,6 +86,8 @@ function createDescriptor(
       .object({
         title: z.record(z.any()).optional(),
         adminTitle: z.string().optional(),
+        publishedAt: z.date().optional(),
+        expiresAt: z.date().nullable().optional(),
       })
       .passthrough(),
     selectSchema: z.object({ id: z.string() }).passthrough(),
@@ -293,6 +297,79 @@ describe("MCP content-management generic operations", () => {
   });
 
   /**
+   * BDD Scenario: Create dry-run coerces date strings
+   * Given Codex prepares a JSON create payload with an ISO-8601 date string
+   * When dryRun is true
+   * Then the validated preview contains a Date and the SDK create method is not called
+   */
+  it("coerces JSON date strings in create previews without invoking SDK writes", async () => {
+    const api = createApi();
+    const registry = [createDescriptor(api)];
+    const publishedAt = "2022-07-06T21:00:00.000Z";
+
+    const result = await createContentModelRecord(
+      {
+        module: "blog",
+        model: "widget",
+        data: {
+          adminTitle: "Scheduled Articles",
+          publishedAt,
+        },
+        dryRun: true,
+      },
+      { registry },
+    );
+
+    expect(result).toEqual({
+      operation: "create",
+      module: "blog",
+      model: "widget",
+      data: {
+        adminTitle: "Scheduled Articles",
+        publishedAt: new Date(publishedAt),
+      },
+    });
+    expect(api.create).not.toHaveBeenCalled();
+  });
+
+  /**
+   * BDD Scenario: Relation create dry-run coerces date strings
+   * Given Codex prepares a JSON relation create payload with a nullable optional date string
+   * When dryRun is true
+   * Then the relation preview validates the coerced Date without invoking SDK writes
+   */
+  it("coerces JSON date strings in relation create previews", async () => {
+    const api = createApi();
+    const registry = [
+      createDescriptor(api, {
+        key: "blog.categories-to-articles",
+        kind: "relation",
+      }),
+    ];
+    const expiresAt = "2023-01-02T03:04:05.000Z";
+
+    await expect(
+      createContentRelationRecord(
+        {
+          module: "blog",
+          relation: "categories-to-articles",
+          data: { expiresAt },
+          dryRun: true,
+        },
+        { registry },
+      ),
+    ).resolves.toEqual({
+      operation: "create",
+      module: "blog",
+      relation: "categories-to-articles",
+      data: {
+        expiresAt: new Date(expiresAt),
+      },
+    });
+    expect(api.create).not.toHaveBeenCalled();
+  });
+
+  /**
    * BDD Scenario: File create from URL uses the file API route
    * Given an AI chat client provides a public image URL for file-storage.file
    * When dryRun is false
@@ -468,6 +545,128 @@ describe("MCP content-management generic operations", () => {
       },
     });
   });
+
+  /**
+   * BDD Scenario: Update forwards coerced date patch
+   * Given Codex prepares a JSON update payload with an ISO-8601 date string
+   * When Codex applies a generic update
+   * Then the SDK receives a Date value with caller auth headers
+   */
+  it("coerces JSON date strings before forwarding update patches", async () => {
+    const api = createApi();
+    const registry = [createDescriptor(api)];
+    const publishedAt = "2022-07-06T21:00:00.000Z";
+
+    await expect(
+      updateContentModelRecord(
+        {
+          module: "blog",
+          model: "widget",
+          id: "widget-1",
+          data: { publishedAt },
+          dryRun: false,
+        },
+        { registry, authHeaders },
+      ),
+    ).resolves.toEqual({
+      id: "widget-1",
+      publishedAt: new Date(publishedAt),
+    });
+
+    expect(api.update).toHaveBeenCalledWith({
+      id: "widget-1",
+      data: {
+        publishedAt: new Date(publishedAt),
+      },
+      options: {
+        headers: authHeaders,
+      },
+    });
+  });
+
+  /**
+   * BDD Scenario: Relation update forwards coerced date patch
+   * Given Codex prepares a JSON relation update payload with an ISO-8601 date string
+   * When Codex applies a generic relation update
+   * Then the SDK receives a Date value with caller auth headers
+   */
+  it("coerces JSON date strings before forwarding relation update patches", async () => {
+    const api = createApi();
+    const registry = [
+      createDescriptor(api, {
+        key: "blog.categories-to-articles",
+        kind: "relation",
+      }),
+    ];
+    const publishedAt = "2024-02-03T04:05:06.000Z";
+
+    await updateContentRelationRecord(
+      {
+        module: "blog",
+        relation: "categories-to-articles",
+        id: "relation-1",
+        data: { publishedAt },
+        dryRun: false,
+      },
+      { registry, authHeaders },
+    );
+
+    expect(api.update).toHaveBeenCalledWith({
+      id: "relation-1",
+      data: {
+        publishedAt: new Date(publishedAt),
+      },
+      options: {
+        headers: authHeaders,
+      },
+    });
+  });
+
+  /**
+   * BDD Scenario: Invalid date payload rejects before writes
+   * Given Codex prepares invalid JSON values for a date field
+   * When Codex applies create and update mutations
+   * Then validation fails before the SDK write methods are invoked
+   */
+  it.each(["not-a-date", 1657141200000, { iso: "2022-07-06T21:00:00.000Z" }])(
+    "rejects invalid JSON date value %p before SDK writes",
+    async (publishedAt) => {
+      const api = createApi();
+      const registry = [createDescriptor(api)];
+
+      await expect(
+        createContentModelRecord(
+          {
+            module: "blog",
+            model: "widget",
+            data: { publishedAt },
+            dryRun: false,
+          },
+          { registry },
+        ),
+      ).rejects.toThrow(
+        'Validation error. Field "publishedAt" must be a valid ISO-8601 date string.',
+      );
+
+      await expect(
+        updateContentModelRecord(
+          {
+            module: "blog",
+            model: "widget",
+            id: "widget-1",
+            data: { publishedAt },
+            dryRun: false,
+          },
+          { registry },
+        ),
+      ).rejects.toThrow(
+        'Validation error. Field "publishedAt" must be a valid ISO-8601 date string.',
+      );
+
+      expect(api.create).not.toHaveBeenCalled();
+      expect(api.update).not.toHaveBeenCalled();
+    },
+  );
 
   /**
    * BDD Scenario: Delete requires preview token before apply

--- a/apps/mcp/lib/content-management/operations.ts
+++ b/apps/mcp/lib/content-management/operations.ts
@@ -1,3 +1,4 @@
+import { z } from "zod";
 import {
   ContentCreateInputSchema,
   ContentDeleteApplyInputSchema,
@@ -114,11 +115,107 @@ function requireOperation(
   }
 }
 
+function unwrapSchema(
+  schema: z.ZodTypeAny | undefined,
+): z.ZodTypeAny | undefined {
+  let current = schema;
+
+  while (current) {
+    const definition = (current as any)._def;
+    const typeName = definition?.typeName ?? definition?.type;
+
+    if (
+      [
+        "ZodOptional",
+        "ZodNullable",
+        "ZodDefault",
+        "ZodCatch",
+        "ZodBranded",
+        "optional",
+        "nullable",
+        "default",
+        "catch",
+        "branded",
+      ].includes(typeName)
+    ) {
+      current = definition.innerType ?? definition.type;
+      continue;
+    }
+
+    if (typeName === "ZodEffects" || typeName === "effects") {
+      current = definition.schema;
+      continue;
+    }
+
+    if (typeName === "ZodPipeline" || typeName === "pipe") {
+      current = definition.out;
+      continue;
+    }
+
+    return current;
+  }
+
+  return current;
+}
+
+function isDateSchema(schema: z.ZodTypeAny | undefined) {
+  const unwrapped = unwrapSchema(schema);
+
+  const definition = (unwrapped as any)?._def;
+
+  return (
+    definition?.typeName === "ZodDate" ||
+    definition?.type === "date" ||
+    unwrapped instanceof z.ZodDate
+  );
+}
+
+function coerceJsonDateFields(
+  descriptor: IContentEntityDescriptor,
+  data: Record<string, unknown>,
+) {
+  const shape = descriptor.insertSchema.shape;
+  const coerced = { ...data };
+
+  Object.entries(shape).forEach(([field, schema]) => {
+    if (!isDateSchema(schema as z.ZodTypeAny | undefined)) {
+      return;
+    }
+
+    const value = coerced[field];
+
+    if (value === undefined || value === null || value instanceof Date) {
+      return;
+    }
+
+    if (typeof value !== "string") {
+      throw new Error(
+        `Validation error. Field "${field}" must be a valid ISO-8601 date string.`,
+      );
+    }
+
+    const isIsoDateString = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/.test(value);
+    const date = new Date(value);
+
+    if (!isIsoDateString || Number.isNaN(date.getTime())) {
+      throw new Error(
+        `Validation error. Field "${field}" must be a valid ISO-8601 date string.`,
+      );
+    }
+
+    coerced[field] = date;
+  });
+
+  return coerced;
+}
+
 function parseCreateData(
   descriptor: IContentEntityDescriptor,
   data: Record<string, unknown>,
 ) {
-  const parsed = descriptor.insertSchema.safeParse(data);
+  const parsed = descriptor.insertSchema.safeParse(
+    coerceJsonDateFields(descriptor, data),
+  );
 
   if (!parsed.success) {
     throw new Error(parsed.error.message);
@@ -131,7 +228,9 @@ function parseUpdateData(
   descriptor: IContentEntityDescriptor,
   data: Record<string, unknown>,
 ) {
-  const parsed = descriptor.insertSchema.partial().safeParse(data);
+  const parsed = descriptor.insertSchema
+    .partial()
+    .safeParse(coerceJsonDateFields(descriptor, data));
 
   if (!parsed.success) {
     throw new Error(parsed.error.message);


### PR DESCRIPTION
### Motivation

- Ensure date fields submitted as JSON ISO-8601 strings are coerced to `Date` instances before validation and SDK writes so integrations can send dates as strings.
- Reject non-string or malformed date values early to avoid forwarding invalid payloads to downstream SDKs.

### Description

- Added `unwrapSchema`, `isDateSchema`, and `coerceJsonDateFields` helpers and imported `z` to detect date fields (including optional/nullable wrappers) and coerce ISO-8601 strings to `Date` objects.
- Updated `parseCreateData` and `parseUpdateData` to run `coerceJsonDateFields` before schema validation so parsed data contains real `Date` instances for date fields.
- Extended the test descriptor schema with `publishedAt` and `expiresAt` date fields and added tests covering create/update and relation create/update dry-run behavior with date string coercion and invalid date rejection.

### Testing

- Ran the content-management unit test suite with `jest` for `apps/mcp/lib/content-management/operations.spec.ts` and all tests completed successfully.
- Added tests include: `coerces JSON date strings in create previews without invoking SDK writes`, `coerces JSON date strings in relation create previews`, `coerces JSON date strings before forwarding update patches`, `coerces JSON date strings before forwarding relation update patches`, and `rejects invalid JSON date value %p before SDK writes`, and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a723e2890308332a83c4d0c029b9507)